### PR TITLE
Improve unsupported exchange error handling

### DIFF
--- a/crypto_bot/execution/cex_executor.py
+++ b/crypto_bot/execution/cex_executor.py
@@ -37,7 +37,15 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
     compatibility when WebSocket trading is desired without ccxt.pro.
     """
 
-    exchange_name = config.get("exchange", "coinbase")
+    supported_exchanges = ("coinbase", "kraken")
+
+    exchange_cfg = config.get("exchange", "coinbase")
+    if isinstance(exchange_cfg, dict):
+        exchange_name = exchange_cfg.get("name") or exchange_cfg.get("id") or ""
+    else:
+        exchange_name = str(exchange_cfg)
+    exchange_name = exchange_name.lower()
+
     use_ws = config.get("use_websocket", False)
 
     ws_client: Optional[KrakenWSClient] = None
@@ -76,7 +84,11 @@ def get_exchange(config) -> Tuple[ccxt.Exchange, Optional[KrakenWSClient]]:
             }
         )
     else:
-        raise ValueError(f"Unsupported exchange: {exchange_name}")
+        raise ValueError(
+            "Unsupported exchange: {}. Supported exchanges: {}".format(
+                exchange_name or "unknown", ", ".join(supported_exchanges)
+            )
+        )
 
     exchange.options["ws_scan"] = config.get("use_websocket", False)
 

--- a/tests/test_cex_executor.py
+++ b/tests/test_cex_executor.py
@@ -241,6 +241,18 @@ def test_get_exchange_websocket_missing_creds(monkeypatch):
     assert ws is None
 
 
+def test_get_exchange_reports_supported(monkeypatch):
+    config = {"exchange": {"name": "foo"}}
+
+    with pytest.raises(ValueError) as exc:
+        cex_executor.get_exchange(config)
+
+    msg = str(exc.value)
+    assert "Unsupported exchange: foo" in msg
+    assert "coinbase" in msg and "kraken" in msg
+    assert "{" not in msg
+
+
 class SlippageExchange:
     def fetch_ticker(self, symbol):
         return {"bid": 100, "ask": 110}


### PR DESCRIPTION
## Summary
- Sanitize exchange config to extract name and list supported exchanges in error message
- Add regression test ensuring unsupported exchanges only echo the name and display valid options

## Testing
- `pytest -q` *(fails: missing dependencies and async plugins)*
- `pytest tests/test_cex_executor.py::test_get_exchange_reports_supported -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae295acb648330b6fe943ad4133267