### PR TITLE
Remove duplicate python-multipart dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dependencies = [
     "rich>=12.0.0,<14.0.0",
     "typer>=0.7.0,<0.10.0",
     "loguru>=0.6.0,<0.8.0",
-    "python-multipart>=0.0.5",
     "email-validator>=2.0.0,<3.0.0",
 
     # Telegram Bot


### PR DESCRIPTION
## Summary
- remove the redundant python-multipart entry from the core dependencies list
- verify no other duplicate dependencies remain in the project configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9706620d08330a2fa2f2ec7b4ee91