### PR TITLE
Remove redundant statsmodels requirement comment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ base58
 gunicorn
 gevent
 urllib3<2.0  # Downgrade to v1.x for LibreSSL compatibility
-# statsmodels  # Duplicate entry removed
 
 dependency-injector>=4.41.0
 


### PR DESCRIPTION
## Summary
- remove the stale comment referencing the duplicate `statsmodels` requirement entry
- re-run dependency resolution to ensure the dependency list remains intact

## Testing
- pip install --dry-run -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68c97074a12c83309434d620c7c88845