### PR TITLE
Refactor indicator calculations into shared utilities

### DIFF
--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from crypto_bot import grid_state
 from crypto_bot.utils.indicator_cache import cache_series
+from crypto_bot.utils.indicators import calculate_atr
 from crypto_bot.utils.volatility import normalize_score_by_volatility, atr_percent
 from crypto_bot.volatility_filter import calc_atr
 
@@ -215,12 +216,7 @@ def generate_signal(
     if range_size < price * cfg.min_range_pct:
         return 0.0, "none"
 
-    # Calculate ATR manually
-    high_low = recent["high"] - recent["low"]
-    high_close = (recent["high"] - recent["close"].shift(1)).abs()
-    low_close = (recent["low"] - recent["close"].shift(1)).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr_series = tr.rolling(window=atr_period).mean()
+    atr_series = calculate_atr(recent, window=atr_period)
     vwap_series = compute_vwap(recent, volume_ma_window)
 
     lookback = len(recent)

--- a/crypto_bot/strategy/market_making_bot.py
+++ b/crypto_bot/strategy/market_making_bot.py
@@ -24,6 +24,7 @@ import ta
 
 
 from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.indicators import calculate_atr
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 
 logger = setup_logger(__name__, LOG_DIR / "market_making.log")
@@ -358,12 +359,7 @@ def generate_signal(df: pd.DataFrame, config: Optional[dict] = None) -> Tuple[fl
     low_diff = df["low"].diff()
     dm_plus = ((high_diff > low_diff) & (high_diff > 0)) * high_diff
     dm_minus = ((low_diff > high_diff) & (low_diff > 0)) * (-low_diff)
-    tr = pd.concat([
-        df["high"] - df["low"],
-        (df["high"] - df["close"].shift(1)).abs(),
-        (df["low"] - df["close"].shift(1)).abs()
-    ], axis=1).max(axis=1)
-    atr = tr.rolling(window=14).mean()
+    atr = calculate_atr(df, window=14)
     di_plus = 100 * (dm_plus.rolling(window=14).mean() / atr)
     di_minus = 100 * (dm_minus.rolling(window=14).mean() / atr)
     dx = 100 * ((di_plus - di_minus).abs() / (di_plus + di_minus))

--- a/crypto_bot/strategy/meme_wave_bot.py
+++ b/crypto_bot/strategy/meme_wave_bot.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 
 from ..sentiment_filter import get_lunarcrush_sentiment_boost, get_sentiment_score
+from crypto_bot.utils.indicators import calculate_atr
 
 logger = logging.getLogger(__name__)
 
@@ -55,14 +56,14 @@ def generate_signal(
     price_change = float(df["close"].iloc[-1] - df["close"].iloc[-2]) if len(df) > 1 else 0.0
     vol = float(df["volume"].iloc[-1])
     
-    # Calculate ATR manually
+    # Calculate ATR using shared helper
     try:
-        high_low = df["high"] - df["low"]
-        high_close = (df["high"] - df["close"].shift(1)).abs()
-        low_close = (df["low"] - df["close"].shift(1)).abs()
-        tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-        atr_series = tr.rolling(window=atr_window).mean()
-        atr_value = atr_series.iloc[-1] if len(atr_series) > 0 and not pd.isna(atr_series.iloc[-1]) else 0.0
+        atr_series = calculate_atr(df, window=atr_window)
+        atr_value = (
+            atr_series.iloc[-1]
+            if len(atr_series) > 0 and not pd.isna(atr_series.iloc[-1])
+            else 0.0
+        )
     except Exception as e:
         logger.warning(f"Failed to calculate ATR: {e}")
         atr_value = 0.0

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from crypto_bot.strategy._config_utils import apply_defaults, extract_params
 from crypto_bot.utils.indicator_cache import cache_series
+from crypto_bot.utils.indicators import calculate_rsi
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.ml_utils import init_ml_or_warn, load_model
 import numpy as np
@@ -94,12 +95,7 @@ def generate_signal(
     dc_low = recent["low"].rolling(window).min().shift(1)
     vol_ma = recent["volume"].rolling(vol_window).mean()
     vol_std = recent["volume"].rolling(vol_window).std()
-    # Calculate RSI manually
-    delta = recent["close"].diff()
-    gain = (delta.where(delta > 0, 0)).rolling(window=rsi_window).mean()
-    loss = (-delta.where(delta < 0, 0)).rolling(window=rsi_window).mean()
-    rs = gain / loss
-    rsi = 100 - (100 / (1 + rs))
+    rsi = calculate_rsi(recent["close"], window=rsi_window)
 
     # Calculate MACD manually
     ema_fast = recent["close"].ewm(span=macd_fast, adjust=False).mean()

--- a/crypto_bot/strategy/momentum_exploiter.py
+++ b/crypto_bot/strategy/momentum_exploiter.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass
 
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.indicator_cache import cache_series
+from crypto_bot.utils.indicators import (
+    calculate_atr,
+    calculate_bollinger_bands,
+    calculate_rsi,
+)
 
 
 @dataclass
@@ -78,27 +83,16 @@ def _calculate_momentum_indicators(df: pd.DataFrame, config: MomentumExploiterCo
         df['volume'].rolling(window=config.volume_window).std()
     )
     
-    # Calculate RSI manually
-    delta = df['close'].diff()
-    gain = (delta.where(delta > 0, 0)).rolling(window=config.rsi_window).mean()
-    loss = (-delta.where(delta < 0, 0)).rolling(window=config.rsi_window).mean()
-    rs = gain / loss
-    indicators['rsi'] = 100 - (100 / (1 + rs))
+    indicators['rsi'] = calculate_rsi(df['close'], window=config.rsi_window)
 
-    # Calculate ATR manually
-    high_low = df['high'] - df['low']
-    high_close = (df['high'] - df['close'].shift(1)).abs()
-    low_close = (df['low'] - df['close'].shift(1)).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    indicators['atr'] = tr.rolling(window=config.momentum_window).mean()
+    indicators['atr'] = calculate_atr(df, window=config.momentum_window)
 
-    # Calculate Bollinger Bands manually
-    bb_mid = df['close'].rolling(config.momentum_window).mean()
-    bb_std = df['close'].rolling(config.momentum_window).std()
-    bb_width = (bb_std * 4) / bb_mid  # 2 standard deviations on each side
-    indicators['bb_upper'] = bb_mid + (bb_width / 2)
-    indicators['bb_lower'] = bb_mid - (bb_width / 2)
-    indicators['bb_width'] = (indicators['bb_upper'] - indicators['bb_lower']) / df['close']
+    bb = calculate_bollinger_bands(
+        df['close'], window=config.momentum_window, num_std=2
+    )
+    indicators['bb_upper'] = bb.upper
+    indicators['bb_lower'] = bb.lower
+    indicators['bb_width'] = bb.width / df['close']
     
     # Calculate MACD manually
     ema_fast = df['close'].ewm(span=8, adjust=False).mean()

--- a/crypto_bot/strategy/range_arb_bot.py
+++ b/crypto_bot/strategy/range_arb_bot.py
@@ -20,6 +20,7 @@ from scipy import stats
 from scipy.optimize import fmin_l_bfgs_b
 from crypto_bot.utils.stats import last_window_zscore
 from crypto_bot.utils.indicator_cache import cache_series
+from crypto_bot.utils.indicators import calculate_atr
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.ml_utils import init_ml_or_warn, load_model
 
@@ -134,12 +135,7 @@ def generate_signal(
 
     recent = df.iloc[-lookback:].copy()
 
-    # Calculate ATR manually
-    high_low = recent["high"] - recent["low"]
-    high_close = (recent["high"] - recent["close"].shift(1)).abs()
-    low_close = (recent["low"] - recent["close"].shift(1)).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr = tr.rolling(window=atr_window).mean()
+    atr = calculate_atr(recent, window=atr_window)
     vol_ma = recent["volume"].rolling(kr_window).mean()
     atr_z = pd.Series(stats.zscore(atr), index=atr.index)
     vol_z = pd.Series(stats.zscore(recent["volume"]), index=recent.index)

--- a/crypto_bot/strategy/sniper_bot.py
+++ b/crypto_bot/strategy/sniper_bot.py
@@ -8,6 +8,7 @@ import pandas as pd
 from crypto_bot.strategy._config_utils import apply_defaults, extract_params
 from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.pair_cache import load_liquid_pairs
+from crypto_bot.utils.indicators import calculate_atr
 from crypto_bot.volatility_filter import calc_atr
 
 DEFAULT_PAIRS = ["BTC/USD", "ETH/USD"]
@@ -156,12 +157,7 @@ def generate_signal(
 
     atr_window = min(atr_window, len(df))
 
-    # Calculate ATR manually
-    high_low = df["high"] - df["low"]
-    high_close = (df["high"] - df["close"].shift(1)).abs()
-    low_close = (df["low"] - df["close"].shift(1)).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    atr_series = tr.rolling(window=atr_window).mean()
+    atr_series = calculate_atr(df, window=atr_window)
     atr = float(atr_series.iloc[-1]) if len(atr_series) and not pd.isna(atr_series.iloc[-1]) else 0.0
 
     if len(df) > volume_window:

--- a/crypto_bot/utils/indicators.py
+++ b/crypto_bot/utils/indicators.py
@@ -1,0 +1,111 @@
+"""Utility functions for computing technical indicators."""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional
+
+import pandas as pd
+
+
+class BollingerBands(NamedTuple):
+    """Container for Bollinger Band calculations."""
+
+    middle: pd.Series
+    upper: pd.Series
+    lower: pd.Series
+    width: pd.Series
+
+
+def _as_series(data: pd.Series | pd.Index | list | tuple) -> pd.Series:
+    """Return ``data`` as a pandas Series."""
+    if isinstance(data, pd.Series):
+        return data
+    return pd.Series(data)
+
+
+def calculate_bollinger_bands(
+    close: pd.Series | pd.Index | list | tuple,
+    window: int = 20,
+    num_std: float = 2.0,
+    *,
+    min_periods: Optional[int] = None,
+) -> BollingerBands:
+    """Calculate Bollinger Bands for ``close`` prices."""
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    if min_periods is None:
+        min_periods = window
+    series = _as_series(close).astype(float)
+    rolling = series.rolling(window=window, min_periods=min_periods)
+    middle = rolling.mean()
+    std = rolling.std()
+    upper = middle + (std * num_std)
+    lower = middle - (std * num_std)
+    width = upper - lower
+    return BollingerBands(middle=middle, upper=upper, lower=lower, width=width)
+
+
+def calculate_rsi(
+    close: pd.Series | pd.Index | list | tuple,
+    window: int = 14,
+    *,
+    min_periods: Optional[int] = None,
+    method: str = "sma",
+) -> pd.Series:
+    """Calculate the Relative Strength Index."""
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    if min_periods is None:
+        min_periods = window
+    series = _as_series(close).astype(float)
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    if method.lower() == "ema":
+        avg_gain = gain.ewm(alpha=1 / window, adjust=False, min_periods=min_periods).mean()
+        avg_loss = loss.ewm(alpha=1 / window, adjust=False, min_periods=min_periods).mean()
+    elif method.lower() == "sma":
+        avg_gain = gain.rolling(window=window, min_periods=min_periods).mean()
+        avg_loss = loss.rolling(window=window, min_periods=min_periods).mean()
+    else:
+        raise ValueError("method must be 'sma' or 'ema'")
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+
+def calculate_atr(
+    data: pd.DataFrame,
+    window: int = 14,
+    *,
+    high_col: str = "high",
+    low_col: str = "low",
+    close_col: str = "close",
+    min_periods: Optional[int] = None,
+    use_ema: bool = False,
+) -> pd.Series:
+    """Calculate the Average True Range."""
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    if min_periods is None:
+        min_periods = window
+    high = data[high_col].astype(float)
+    low = data[low_col].astype(float)
+    close = data[close_col].astype(float)
+    high_low = high - low
+    high_close = (high - close.shift(1)).abs()
+    low_close = (low - close.shift(1)).abs()
+    true_range = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    if use_ema:
+        atr = true_range.ewm(span=window, adjust=False, min_periods=min_periods).mean()
+    else:
+        atr = true_range.rolling(window=window, min_periods=min_periods).mean()
+    return atr
+
+
+__all__ = [
+    "BollingerBands",
+    "calculate_atr",
+    "calculate_bollinger_bands",
+    "calculate_rsi",
+]

--- a/crypto_bot/utils/volatility.py
+++ b/crypto_bot/utils/volatility.py
@@ -1,6 +1,7 @@
 import math
 import pandas as pd
 import ta
+from crypto_bot.utils.indicators import calculate_atr
 from crypto_bot.volatility_filter import calc_atr
 
 
@@ -9,12 +10,7 @@ def atr_percent(df: pd.DataFrame, window: int = 14) -> float:
     if df.empty or not {"high", "low", "close"}.issubset(df.columns):
         return 0.0
 
-    # Calculate ATR manually
-    high_low = df["high"] - df["low"]
-    high_close = (df["high"] - df["close"].shift(1)).abs()
-    low_close = (df["low"] - df["close"].shift(1)).abs()
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    series = tr.rolling(window=window).mean()
+    series = calculate_atr(df, window=window)
     if series.empty or len(series.dropna()) == 0:
         return 0.0
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,77 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from crypto_bot.utils.indicators import (
+    BollingerBands,
+    calculate_atr,
+    calculate_bollinger_bands,
+    calculate_rsi,
+)
+
+
+def test_calculate_rsi_matches_manual():
+    close = pd.Series([1, 2, 3, 2, 4, 5, 6], dtype=float)
+    window = 3
+
+    delta = close.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    avg_gain = gain.rolling(window=window, min_periods=window).mean()
+    avg_loss = loss.rolling(window=window, min_periods=window).mean()
+    rs = avg_gain / avg_loss
+    expected = 100 - (100 / (1 + rs))
+
+    result = calculate_rsi(close, window=window)
+    pd.testing.assert_series_equal(result, expected, check_names=False)
+
+
+def test_calculate_atr_matches_manual():
+    data = pd.DataFrame(
+        {
+            "high": [10, 12, 13, 11, 14, 15],
+            "low": [8, 9, 10, 9, 11, 12],
+            "close": [9, 11, 12, 10, 13, 14],
+        }
+    )
+    window = 3
+
+    high_low = data["high"] - data["low"]
+    high_close = (data["high"] - data["close"].shift(1)).abs()
+    low_close = (data["low"] - data["close"].shift(1)).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    expected = tr.rolling(window=window, min_periods=window).mean()
+
+    result = calculate_atr(data, window=window)
+    pd.testing.assert_series_equal(result, expected, check_names=False)
+
+
+def test_calculate_bollinger_bands_matches_manual():
+    close = pd.Series(np.linspace(100, 110, num=10))
+    window = 4
+    num_std = 2.5
+
+    rolling = close.rolling(window=window, min_periods=window)
+    middle = rolling.mean()
+    std = rolling.std()
+    upper = middle + std * num_std
+    lower = middle - std * num_std
+    width = upper - lower
+
+    bands = calculate_bollinger_bands(close, window=window, num_std=num_std)
+
+    assert isinstance(bands, BollingerBands)
+    pd.testing.assert_series_equal(bands.middle, middle, check_names=False)
+    pd.testing.assert_series_equal(bands.upper, upper, check_names=False)
+    pd.testing.assert_series_equal(bands.lower, lower, check_names=False)
+    pd.testing.assert_series_equal(bands.width, width, check_names=False)
+
+
+def test_invalid_window_raises_value_error():
+    series = pd.Series([1, 2, 3])
+    with pytest.raises(ValueError):
+        calculate_rsi(series, window=0)
+    with pytest.raises(ValueError):
+        calculate_atr(pd.DataFrame({"high": series, "low": series, "close": series}), window=0)
+    with pytest.raises(ValueError):
+        calculate_bollinger_bands(series, window=0)


### PR DESCRIPTION
## Summary
- add a dedicated crypto_bot/utils/indicators.py module with reusable ATR, RSI, and Bollinger Band helpers
- refactor strategy, regime, and backtest modules to rely on the shared helpers instead of inline calculations
- introduce tests/test_indicators.py to validate the new indicator helpers and ensure API guardrails

## Testing
- pytest tests/test_indicators.py

------
https://chatgpt.com/codex/tasks/task_e_68c981b9e67c8330a2c4edff9bac6b44