### PR TITLE
Introduce strategy base class and unify loader usage

### DIFF
--- a/crypto_bot/meta_selector.py
+++ b/crypto_bot/meta_selector.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
+from crypto_bot.strategy import STRATEGY_ALIASES, get_strategy
 from crypto_bot.utils.logger import LOG_DIR
 from datetime import datetime
 
@@ -68,84 +69,12 @@ class MetaRegressor:
 
 
 def _get_strategy_function(strategy_name: str):
-    """Lazy import strategy functions to avoid circular dependencies."""
-    try:
-        if strategy_name in ["trend", "trend_bot"]:
-            from crypto_bot.strategy import trend_bot
-            return trend_bot.generate_signal
-        elif strategy_name in ["grid", "grid_bot"]:
-            from crypto_bot.strategy import grid_bot
-            return grid_bot.generate_signal
-        elif strategy_name in ["sniper", "sniper_bot"]:
-            from crypto_bot.strategy import sniper_bot
-            return sniper_bot.generate_signal
-        elif strategy_name in ["dex_scalper", "dex_scalper_bot"]:
-            from crypto_bot.strategy import dex_scalper
-            return dex_scalper.generate_signal
-        elif strategy_name in ["mean_bot"]:
-            from crypto_bot.strategy import mean_bot
-            return mean_bot.generate_signal
-        elif strategy_name in ["breakout_bot"]:
-            from crypto_bot.strategy import breakout_bot
-            return breakout_bot.generate_signal
-        elif strategy_name in ["micro_scalp", "micro_scalp_bot"]:
-            from crypto_bot.strategy import micro_scalp_bot
-            return micro_scalp_bot.generate_signal
-        elif strategy_name in ["bounce_scalper", "bounce_scalper_bot"]:
-            from crypto_bot.strategy import bounce_scalper
-            return bounce_scalper.generate_signal
-        elif strategy_name in ["solana_scalping", "solana_scalping_bot"]:
-            from crypto_bot.strategy import solana_scalping
-            return solana_scalping.generate_signal
-        elif strategy_name in ["dca", "dca_bot"]:
-            from crypto_bot.strategy import dca_bot
-            return dca_bot.generate_signal
-        elif strategy_name in ["momentum", "momentum_bot"]:
-            from crypto_bot.strategy import momentum_bot
-            return momentum_bot.generate_signal
-        elif strategy_name in ["lstm", "lstm_bot"]:
-            from crypto_bot.strategy import lstm_bot
-            return lstm_bot.generate_signal
-        elif strategy_name in ["ultra_scalp", "ultra_scalp_bot"]:
-            from crypto_bot.strategy import ultra_scalp_bot
-            return ultra_scalp_bot.generate_signal
-        elif strategy_name in ["volatility_harvester"]:
-            from crypto_bot.strategy import volatility_harvester
-            return volatility_harvester.generate_signal
-        elif strategy_name in ["hft_engine"]:
-            from crypto_bot.strategy import hft_engine
-            return hft_engine.generate_signal
-        elif strategy_name in ["maker_spread"]:
-            from crypto_bot.strategy import maker_spread
-            return maker_spread.generate_signal
-        elif strategy_name in ["flash_crash_bot"]:
-            from crypto_bot.strategy import flash_crash_bot
-            return flash_crash_bot.generate_signal
-        elif strategy_name in ["meme_wave_bot"]:
-            from crypto_bot.strategy import meme_wave_bot
-            return meme_wave_bot.generate_signal
-        elif strategy_name in ["cross_chain_arb_bot"]:
-            from crypto_bot.strategy import cross_chain_arb_bot
-            return cross_chain_arb_bot.generate_signal
-        elif strategy_name in ["dip_hunter"]:
-            from crypto_bot.strategy import dip_hunter
-            return dip_hunter.generate_signal
-        elif strategy_name in ["range_arb_bot"]:
-            from crypto_bot.strategy import range_arb_bot
-            return range_arb_bot.generate_signal
-        elif strategy_name in ["stat_arb_bot"]:
-            from crypto_bot.strategy import stat_arb_bot
-            return stat_arb_bot.generate_signal
-        elif strategy_name in ["momentum_exploiter"]:
-            from crypto_bot.strategy import momentum_exploiter
-            return momentum_exploiter.generate_signal
-        elif strategy_name in ["arbitrage_engine"]:
-            from crypto_bot.strategy import arbitrage_engine
-            return arbitrage_engine.generate_signal
-        else:
-            return None
-    except ImportError:
+    """Return the strategy callable for ``strategy_name`` if available."""
+
+    strategy = get_strategy(strategy_name)
+    if strategy is None:
         return None
+    return strategy.generate_signal
 
 # Strategy map will be populated lazily when needed
 _STRATEGY_FN_MAP = {}
@@ -157,45 +86,45 @@ def get_strategy_by_name(
     """Return the strategy function mapped to ``name`` if present."""
     # Populate the strategy map lazily if it's empty
     if not _STRATEGY_FN_MAP:
-        _STRATEGY_FN_MAP.update({
-            "trend": _get_strategy_function("trend"),
-            "trend_bot": _get_strategy_function("trend_bot"),
-            "grid": _get_strategy_function("grid"),
-            "grid_bot": _get_strategy_function("grid_bot"),
-            "sniper": _get_strategy_function("sniper"),
-            "sniper_bot": _get_strategy_function("sniper_bot"),
-            "dex_scalper": _get_strategy_function("dex_scalper"),
-            "dex_scalper_bot": _get_strategy_function("dex_scalper_bot"),
-            "mean_bot": _get_strategy_function("mean_bot"),
-            "breakout_bot": _get_strategy_function("breakout_bot"),
-            "micro_scalp": _get_strategy_function("micro_scalp"),
-            "micro_scalp_bot": _get_strategy_function("micro_scalp_bot"),
-            "bounce_scalper": _get_strategy_function("bounce_scalper"),
-            "bounce_scalper_bot": _get_strategy_function("bounce_scalper_bot"),
-            "solana_scalping": _get_strategy_function("solana_scalping"),
-            "solana_scalping_bot": _get_strategy_function("solana_scalping_bot"),
-            "dca": _get_strategy_function("dca"),
-            "dca_bot": _get_strategy_function("dca_bot"),
-            "momentum": _get_strategy_function("momentum"),
-            "momentum_bot": _get_strategy_function("momentum_bot"),
-            "lstm": _get_strategy_function("lstm"),
-            "lstm_bot": _get_strategy_function("lstm_bot"),
-            "ultra_scalp": _get_strategy_function("ultra_scalp"),
-            "ultra_scalp_bot": _get_strategy_function("ultra_scalp_bot"),
-            "volatility_harvester": _get_strategy_function("volatility_harvester"),
-            "hft_engine": _get_strategy_function("hft_engine"),
-            "maker_spread": _get_strategy_function("maker_spread"),
-            "flash_crash_bot": _get_strategy_function("flash_crash_bot"),
-            "meme_wave_bot": _get_strategy_function("meme_wave_bot"),
-            "cross_chain_arb_bot": _get_strategy_function("cross_chain_arb_bot"),
-            "dip_hunter": _get_strategy_function("dip_hunter"),
-            "range_arb_bot": _get_strategy_function("range_arb_bot"),
-            "stat_arb_bot": _get_strategy_function("stat_arb_bot"),
-            "momentum_exploiter": _get_strategy_function("momentum_exploiter"),
-            "arbitrage_engine": _get_strategy_function("arbitrage_engine"),
-        })
-    
-    return _STRATEGY_FN_MAP.get(name)
+        canonical = [
+            "trend_bot",
+            "grid_bot",
+            "sniper_bot",
+            "dex_scalper",
+            "mean_bot",
+            "breakout_bot",
+            "micro_scalp_bot",
+            "bounce_scalper",
+            "solana_scalping",
+            "dca_bot",
+            "momentum_bot",
+            "lstm_bot",
+            "ultra_scalp_bot",
+            "volatility_harvester",
+            "hft_engine",
+            "maker_spread",
+            "flash_crash_bot",
+            "meme_wave_bot",
+            "cross_chain_arb_bot",
+            "dip_hunter",
+            "range_arb_bot",
+            "stat_arb_bot",
+            "momentum_exploiter",
+            "arbitrage_engine",
+        ]
+        for canonical_name in canonical:
+            fn = _get_strategy_function(canonical_name)
+            if fn is not None:
+                _STRATEGY_FN_MAP[canonical_name] = fn
+        for alias, canonical_name in STRATEGY_ALIASES.items():
+            fn = _STRATEGY_FN_MAP.get(canonical_name)
+            if fn is None:
+                fn = _get_strategy_function(alias)
+            if fn is not None:
+                _STRATEGY_FN_MAP.setdefault(alias, fn)
+
+    canonical_name = STRATEGY_ALIASES.get(name, name)
+    return _STRATEGY_FN_MAP.get(name) or _STRATEGY_FN_MAP.get(canonical_name)
 
 
 def _load() -> Dict[str, Dict[str, List[dict]]]:

--- a/crypto_bot/rl/strategy_selector.py
+++ b/crypto_bot/rl/strategy_selector.py
@@ -6,38 +6,34 @@ from pathlib import Path
 from crypto_bot.utils.logger import LOG_DIR
 from typing import Callable, Dict
 
-from crypto_bot.strategy import (
-    trend_bot,
-    grid_bot,
-    sniper_bot,
-    dex_scalper,
-    dca_bot,
-    mean_bot,
-    breakout_bot,
-    solana_scalping,
-)
+from crypto_bot.strategy import STRATEGY_ALIASES, get_strategy
 
 # Default log file location
 LOG_FILE = Path("crypto_bot/logs/strategy_pnl.csv")
 
 # Map strategy names to generation functions
 _STRATEGY_FN_MAP: Dict[str, Callable[[pd.DataFrame], tuple]] = {}
-if trend_bot is not None:
-    _STRATEGY_FN_MAP["trend_bot"] = trend_bot.generate_signal
-if grid_bot is not None:
-    _STRATEGY_FN_MAP["grid_bot"] = grid_bot.generate_signal
-if sniper_bot is not None:
-    _STRATEGY_FN_MAP["sniper_bot"] = sniper_bot.generate_signal
-if dex_scalper is not None:
-    _STRATEGY_FN_MAP["dex_scalper"] = dex_scalper.generate_signal
-if dca_bot is not None:
-    _STRATEGY_FN_MAP["dca_bot"] = dca_bot.generate_signal
-if mean_bot is not None:
-    _STRATEGY_FN_MAP["mean_bot"] = mean_bot.generate_signal
-if breakout_bot is not None:
-    _STRATEGY_FN_MAP["breakout_bot"] = breakout_bot.generate_signal
-if solana_scalping is not None:
-    _STRATEGY_FN_MAP["solana_scalping"] = solana_scalping.generate_signal
+for name in [
+    "trend_bot",
+    "grid_bot",
+    "sniper_bot",
+    "dex_scalper",
+    "dca_bot",
+    "mean_bot",
+    "breakout_bot",
+    "solana_scalping",
+]:
+    strategy = get_strategy(name)
+    if strategy is not None:
+        _STRATEGY_FN_MAP[name] = strategy.generate_signal
+
+for alias, canonical in STRATEGY_ALIASES.items():
+    strategy = _STRATEGY_FN_MAP.get(canonical)
+    if strategy is None:
+        obj = get_strategy(alias)
+        strategy = obj.generate_signal if obj is not None else None
+    if strategy is not None:
+        _STRATEGY_FN_MAP.setdefault(alias, strategy)
 
 
 class RLStrategySelector:

--- a/crypto_bot/strategy/base.py
+++ b/crypto_bot/strategy/base.py
@@ -1,0 +1,187 @@
+"""Common strategy interfaces and helpers."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import inspect
+from types import ModuleType
+from typing import Any, Callable, Optional, Protocol, Tuple, runtime_checkable
+
+import pandas as pd
+
+StrategySignal = Tuple[float, str]
+PreHook = Callable[..., pd.DataFrame]
+PostHook = Callable[..., StrategySignal]
+
+
+@runtime_checkable
+class StrategyProtocol(Protocol):
+    """Runtime protocol implemented by all strategy objects."""
+
+    name: str
+
+    def before_generate(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
+        """Hook executed prior to generating a signal."""
+
+    def after_generate(
+        self, signal: StrategySignal, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Hook executed after generating a signal."""
+
+    def generate_signal(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Return the trading signal for ``df``."""
+
+    def __call__(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Allow strategy objects to be used as callables."""
+
+
+class Strategy(StrategyProtocol, ABC):
+    """Base class for all trading strategies."""
+
+    def __init__(self, name: Optional[str] = None) -> None:
+        self.name = name or self.__class__.__name__
+
+    def before_generate(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
+        """Hook executed prior to :meth:`_generate_signal`.
+
+        Sub-classes can override this to normalise the dataframe or augment
+        keyword arguments. The default implementation is a no-op.
+        """
+
+        return df
+
+    def after_generate(
+        self, signal: StrategySignal, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Hook executed after :meth:`_generate_signal`.
+
+        Sub-classes can override this to clamp scores, apply cooldowns or log
+        telemetry information. The default implementation is a no-op.
+        """
+
+        return signal
+
+    def __call__(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        return self.generate_signal(df, *args, **kwargs)
+
+    def generate_signal(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Return the strategy signal, applying hooks if present."""
+
+        prepared = self.before_generate(df, *args, **kwargs)
+        signal = self._generate_signal(prepared, *args, **kwargs)
+        return self.after_generate(signal, prepared, *args, **kwargs)
+
+    @abstractmethod
+    def _generate_signal(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        """Concrete strategy implementation."""
+
+
+class CallableStrategy(Strategy):
+    """Adapter for legacy function-based strategy implementations."""
+
+    def __init__(
+        self,
+        name: str,
+        func: Callable[..., StrategySignal],
+        *,
+        module: ModuleType | None = None,
+        before: PreHook | None = None,
+        after: PostHook | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        self._func = func
+        self._module = module
+        self._before_hook = before
+        self._after_hook = after
+
+    def before_generate(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
+        if self._before_hook is not None:
+            return self._before_hook(df, *args, **kwargs)
+        return super().before_generate(df, *args, **kwargs)
+
+    def after_generate(
+        self, signal: StrategySignal, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        if self._after_hook is not None:
+            return self._after_hook(signal, df, *args, **kwargs)
+        return super().after_generate(signal, df, *args, **kwargs)
+
+    def _generate_signal(
+        self, df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> StrategySignal:
+        return self._func(df, *args, **kwargs)
+
+    @property
+    def module(self) -> ModuleType | None:
+        """Return the underlying module, if one was provided."""
+
+        return self._module
+
+    def __getattr__(self, item: str) -> Any:
+        if self._module is not None and hasattr(self._module, item):
+            return getattr(self._module, item)
+        raise AttributeError(
+            f"{self.__class__.__name__} object has no attribute {item!r}"
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"CallableStrategy(name={self.name!r}, func={self._func!r})"
+
+
+def coerce_to_strategy(obj: Any, *, name: str | None = None) -> StrategyProtocol:
+    """Return a :class:`StrategyProtocol` implementation for ``obj``.
+
+    Existing :class:`StrategyProtocol` instances are returned unchanged. Modules
+    or objects exposing a ``generate_signal`` callable are wrapped in a
+    :class:`CallableStrategy`. ``name`` overrides the inferred strategy name.
+    """
+
+    if isinstance(obj, StrategyProtocol):
+        return obj
+
+    candidate = getattr(obj, "strategy", None)
+    if isinstance(candidate, StrategyProtocol):
+        return candidate
+
+    if inspect.isclass(candidate) and issubclass(candidate, Strategy):  # pragma: no cover - defensive
+        return candidate()  # type: ignore[call-arg]
+
+    if inspect.isclass(obj) and issubclass(obj, Strategy):  # pragma: no cover - defensive
+        return obj()  # type: ignore[call-arg]
+
+    generate_signal = getattr(obj, "generate_signal", None)
+    if callable(generate_signal):
+        strategy_name = (
+            name
+            or getattr(obj, "name", None)
+            or getattr(obj, "__name__", None)
+            or obj.__class__.__name__
+        )
+        module: ModuleType | None = obj if isinstance(obj, ModuleType) else None
+        return CallableStrategy(strategy_name, generate_signal, module=module)
+
+    raise TypeError(f"Object {obj!r} cannot be coerced to a strategy")
+
+
+__all__ = [
+    "Strategy",
+    "StrategySignal",
+    "StrategyProtocol",
+    "CallableStrategy",
+    "coerce_to_strategy",
+]


### PR DESCRIPTION
## Summary
- add a strategy base module with Strategy/CallableStrategy abstractions and a coerce_to_strategy adapter
- refactor the strategy package to expose a registry, alias mapping, and get_strategy helper built on the new base
- update the router, meta selector, and RL selector to consume the unified strategy interface and reuse the registry

## Testing
- pytest tests/strategy/test_signal_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68c983265f288330a2f89842537ba99c