### PR TITLE
Add strategy logging helper and instrument strategies

### DIFF
--- a/crypto_bot/strategy/hft_engine.py
+++ b/crypto_bot/strategy/hft_engine.py
@@ -6,7 +6,7 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Literal
 
-from crypto_bot.utils.logger import LOG_DIR, setup_logger
+from crypto_bot.utils.logging import setup_strategy_logger
 from crypto_bot.execution.cex_executor import execute_trade_async
 
 
@@ -59,7 +59,7 @@ class HFTEngine:
         self.batch_summary_secs = tele_cfg.get("batch_summary_secs", 60)
         self.dry_run = bool(self.fees_cfg.get("dry_run", True))
 
-        self.logger = setup_logger(__name__, LOG_DIR / "hft_engine.log")
+        self.logger = setup_strategy_logger("hft_engine")
         self.notifier = _DummyNotifier(self.logger)
 
         # Active signals keyed by symbol.  Each entry is a mapping containing:

--- a/crypto_bot/utils/logging.py
+++ b/crypto_bot/utils/logging.py
@@ -1,0 +1,37 @@
+"""Utility helpers for configuring strategy loggers."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .logger import LOG_DIR, setup_logger
+
+
+_STRATEGY_LOG_DIR = LOG_DIR / "strategies"
+
+
+def _sanitise_name(name: str) -> str:
+    """Return a filesystem-friendly representation of ``name``."""
+
+    return "".join(
+        ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name.strip()
+    ) or "strategy"
+
+
+def setup_strategy_logger(name: str) -> logging.Logger:
+    """Return a logger configured for use inside strategy modules.
+
+    The logger writes to ``crypto_bot/logs/strategies/<name>.log`` and is
+    configured with standard stream and file handlers via
+    :func:`crypto_bot.utils.logger.setup_logger`.
+    """
+
+    safe_name = _sanitise_name(name)
+    log_path = Path(_STRATEGY_LOG_DIR) / f"{safe_name}.log"
+    logger = setup_logger(f"strategy.{name}", log_path)
+    logger.propagate = False
+    return logger
+
+
+__all__ = ["setup_strategy_logger"]


### PR DESCRIPTION
## Summary
- add crypto_bot.utils.logging with a setup_strategy_logger helper that standardises strategy logging destinations
- refactor strategy modules to initialise their loggers via the helper and add context-rich logging around signal and risk decisions
- enhance dip_hunter oversold handling to treat deep dips near the lower Bollinger band as oversold while documenting the decision via logging

## Testing
- pytest tests/strategy/test_signal_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68c9963af2ec833089c47a63b72484aa