### PR TITLE
Add shared strategy base class and unify loader interfaces

### DIFF
--- a/crypto_bot/meta_selector.py
+++ b/crypto_bot/meta_selector.py
@@ -67,135 +67,175 @@ class MetaRegressor:
         return {k: float(v) for k, v in zip(df.index, preds)}
 
 
+def _resolve_signal(obj: object, alias: str) -> Optional[Callable[[pd.DataFrame], tuple]]:
+    if not obj:
+        return None
+    globals().setdefault(alias, obj)
+    return getattr(obj, "generate_signal", None)
+
+
 def _get_strategy_function(strategy_name: str):
     """Lazy import strategy functions to avoid circular dependencies."""
     try:
         if strategy_name in ["trend", "trend_bot"]:
             from crypto_bot.strategy import trend_bot
-            return trend_bot.generate_signal
+
+            return _resolve_signal(trend_bot, "trend_bot")
         elif strategy_name in ["grid", "grid_bot"]:
             from crypto_bot.strategy import grid_bot
-            return grid_bot.generate_signal
+
+            return _resolve_signal(grid_bot, "grid_bot")
         elif strategy_name in ["sniper", "sniper_bot"]:
             from crypto_bot.strategy import sniper_bot
-            return sniper_bot.generate_signal
+
+            return _resolve_signal(sniper_bot, "sniper_bot")
         elif strategy_name in ["dex_scalper", "dex_scalper_bot"]:
             from crypto_bot.strategy import dex_scalper
-            return dex_scalper.generate_signal
+
+            return _resolve_signal(dex_scalper, "dex_scalper")
         elif strategy_name in ["mean_bot"]:
             from crypto_bot.strategy import mean_bot
-            return mean_bot.generate_signal
+
+            return _resolve_signal(mean_bot, "mean_bot")
         elif strategy_name in ["breakout_bot"]:
             from crypto_bot.strategy import breakout_bot
-            return breakout_bot.generate_signal
+
+            return _resolve_signal(breakout_bot, "breakout_bot")
         elif strategy_name in ["micro_scalp", "micro_scalp_bot"]:
             from crypto_bot.strategy import micro_scalp_bot
-            return micro_scalp_bot.generate_signal
+
+            return _resolve_signal(micro_scalp_bot, "micro_scalp_bot")
         elif strategy_name in ["bounce_scalper", "bounce_scalper_bot"]:
             from crypto_bot.strategy import bounce_scalper
-            return bounce_scalper.generate_signal
+
+            return _resolve_signal(bounce_scalper, "bounce_scalper")
         elif strategy_name in ["solana_scalping", "solana_scalping_bot"]:
             from crypto_bot.strategy import solana_scalping
-            return solana_scalping.generate_signal
+
+            return _resolve_signal(solana_scalping, "solana_scalping")
         elif strategy_name in ["dca", "dca_bot"]:
             from crypto_bot.strategy import dca_bot
-            return dca_bot.generate_signal
+
+            return _resolve_signal(dca_bot, "dca_bot")
         elif strategy_name in ["momentum", "momentum_bot"]:
             from crypto_bot.strategy import momentum_bot
-            return momentum_bot.generate_signal
+
+            return _resolve_signal(momentum_bot, "momentum_bot")
         elif strategy_name in ["lstm", "lstm_bot"]:
             from crypto_bot.strategy import lstm_bot
-            return lstm_bot.generate_signal
+
+            return _resolve_signal(lstm_bot, "lstm_bot")
         elif strategy_name in ["ultra_scalp", "ultra_scalp_bot"]:
             from crypto_bot.strategy import ultra_scalp_bot
-            return ultra_scalp_bot.generate_signal
+
+            return _resolve_signal(ultra_scalp_bot, "ultra_scalp_bot")
         elif strategy_name in ["volatility_harvester"]:
             from crypto_bot.strategy import volatility_harvester
-            return volatility_harvester.generate_signal
+
+            return _resolve_signal(volatility_harvester, "volatility_harvester")
         elif strategy_name in ["hft_engine"]:
             from crypto_bot.strategy import hft_engine
-            return hft_engine.generate_signal
+
+            return _resolve_signal(hft_engine, "hft_engine")
         elif strategy_name in ["maker_spread"]:
             from crypto_bot.strategy import maker_spread
-            return maker_spread.generate_signal
+
+            return _resolve_signal(maker_spread, "maker_spread")
         elif strategy_name in ["flash_crash_bot"]:
             from crypto_bot.strategy import flash_crash_bot
-            return flash_crash_bot.generate_signal
+
+            return _resolve_signal(flash_crash_bot, "flash_crash_bot")
         elif strategy_name in ["meme_wave_bot"]:
             from crypto_bot.strategy import meme_wave_bot
-            return meme_wave_bot.generate_signal
+
+            return _resolve_signal(meme_wave_bot, "meme_wave_bot")
         elif strategy_name in ["cross_chain_arb_bot"]:
             from crypto_bot.strategy import cross_chain_arb_bot
-            return cross_chain_arb_bot.generate_signal
+
+            return _resolve_signal(cross_chain_arb_bot, "cross_chain_arb_bot")
         elif strategy_name in ["dip_hunter"]:
             from crypto_bot.strategy import dip_hunter
-            return dip_hunter.generate_signal
+
+            return _resolve_signal(dip_hunter, "dip_hunter")
         elif strategy_name in ["range_arb_bot"]:
             from crypto_bot.strategy import range_arb_bot
-            return range_arb_bot.generate_signal
+
+            return _resolve_signal(range_arb_bot, "range_arb_bot")
         elif strategy_name in ["stat_arb_bot"]:
             from crypto_bot.strategy import stat_arb_bot
-            return stat_arb_bot.generate_signal
+
+            return _resolve_signal(stat_arb_bot, "stat_arb_bot")
         elif strategy_name in ["momentum_exploiter"]:
             from crypto_bot.strategy import momentum_exploiter
-            return momentum_exploiter.generate_signal
+
+            return _resolve_signal(momentum_exploiter, "momentum_exploiter")
         elif strategy_name in ["arbitrage_engine"]:
             from crypto_bot.strategy import arbitrage_engine
-            return arbitrage_engine.generate_signal
+
+            return _resolve_signal(arbitrage_engine, "arbitrage_engine")
         else:
             return None
     except ImportError:
         return None
 
-# Strategy map will be populated lazily when needed
-_STRATEGY_FN_MAP = {}
+# Strategy map is populated on import so tests can introspect it directly
+_STRATEGY_FN_MAP: Dict[str, Optional[Callable[[pd.DataFrame], tuple]]] = {}
+
+
+def _ensure_strategy_map() -> None:
+    if _STRATEGY_FN_MAP:
+        return
+
+    entries = {
+        "trend": _get_strategy_function("trend"),
+        "trend_bot": _get_strategy_function("trend_bot"),
+        "grid": _get_strategy_function("grid"),
+        "grid_bot": _get_strategy_function("grid_bot"),
+        "sniper": _get_strategy_function("sniper"),
+        "sniper_bot": _get_strategy_function("sniper_bot"),
+        "dex_scalper": _get_strategy_function("dex_scalper"),
+        "dex_scalper_bot": _get_strategy_function("dex_scalper_bot"),
+        "mean_bot": _get_strategy_function("mean_bot"),
+        "breakout_bot": _get_strategy_function("breakout_bot"),
+        "micro_scalp": _get_strategy_function("micro_scalp"),
+        "micro_scalp_bot": _get_strategy_function("micro_scalp_bot"),
+        "bounce_scalper": _get_strategy_function("bounce_scalper"),
+        "bounce_scalper_bot": _get_strategy_function("bounce_scalper_bot"),
+        "solana_scalping": _get_strategy_function("solana_scalping"),
+        "solana_scalping_bot": _get_strategy_function("solana_scalping_bot"),
+        "dca": _get_strategy_function("dca"),
+        "dca_bot": _get_strategy_function("dca_bot"),
+        "momentum": _get_strategy_function("momentum"),
+        "momentum_bot": _get_strategy_function("momentum_bot"),
+        "lstm": _get_strategy_function("lstm"),
+        "lstm_bot": _get_strategy_function("lstm_bot"),
+        "ultra_scalp": _get_strategy_function("ultra_scalp"),
+        "ultra_scalp_bot": _get_strategy_function("ultra_scalp_bot"),
+        "volatility_harvester": _get_strategy_function("volatility_harvester"),
+        "hft_engine": _get_strategy_function("hft_engine"),
+        "maker_spread": _get_strategy_function("maker_spread"),
+        "flash_crash_bot": _get_strategy_function("flash_crash_bot"),
+        "meme_wave_bot": _get_strategy_function("meme_wave_bot"),
+        "cross_chain_arb_bot": _get_strategy_function("cross_chain_arb_bot"),
+        "dip_hunter": _get_strategy_function("dip_hunter"),
+        "range_arb_bot": _get_strategy_function("range_arb_bot"),
+        "stat_arb_bot": _get_strategy_function("stat_arb_bot"),
+        "momentum_exploiter": _get_strategy_function("momentum_exploiter"),
+        "arbitrage_engine": _get_strategy_function("arbitrage_engine"),
+    }
+    _STRATEGY_FN_MAP.update({k: v for k, v in entries.items() if v is not None})
 
 
 def get_strategy_by_name(
     name: str,
 ) -> Optional[Callable[[pd.DataFrame], tuple]]:
     """Return the strategy function mapped to ``name`` if present."""
-    # Populate the strategy map lazily if it's empty
-    if not _STRATEGY_FN_MAP:
-        _STRATEGY_FN_MAP.update({
-            "trend": _get_strategy_function("trend"),
-            "trend_bot": _get_strategy_function("trend_bot"),
-            "grid": _get_strategy_function("grid"),
-            "grid_bot": _get_strategy_function("grid_bot"),
-            "sniper": _get_strategy_function("sniper"),
-            "sniper_bot": _get_strategy_function("sniper_bot"),
-            "dex_scalper": _get_strategy_function("dex_scalper"),
-            "dex_scalper_bot": _get_strategy_function("dex_scalper_bot"),
-            "mean_bot": _get_strategy_function("mean_bot"),
-            "breakout_bot": _get_strategy_function("breakout_bot"),
-            "micro_scalp": _get_strategy_function("micro_scalp"),
-            "micro_scalp_bot": _get_strategy_function("micro_scalp_bot"),
-            "bounce_scalper": _get_strategy_function("bounce_scalper"),
-            "bounce_scalper_bot": _get_strategy_function("bounce_scalper_bot"),
-            "solana_scalping": _get_strategy_function("solana_scalping"),
-            "solana_scalping_bot": _get_strategy_function("solana_scalping_bot"),
-            "dca": _get_strategy_function("dca"),
-            "dca_bot": _get_strategy_function("dca_bot"),
-            "momentum": _get_strategy_function("momentum"),
-            "momentum_bot": _get_strategy_function("momentum_bot"),
-            "lstm": _get_strategy_function("lstm"),
-            "lstm_bot": _get_strategy_function("lstm_bot"),
-            "ultra_scalp": _get_strategy_function("ultra_scalp"),
-            "ultra_scalp_bot": _get_strategy_function("ultra_scalp_bot"),
-            "volatility_harvester": _get_strategy_function("volatility_harvester"),
-            "hft_engine": _get_strategy_function("hft_engine"),
-            "maker_spread": _get_strategy_function("maker_spread"),
-            "flash_crash_bot": _get_strategy_function("flash_crash_bot"),
-            "meme_wave_bot": _get_strategy_function("meme_wave_bot"),
-            "cross_chain_arb_bot": _get_strategy_function("cross_chain_arb_bot"),
-            "dip_hunter": _get_strategy_function("dip_hunter"),
-            "range_arb_bot": _get_strategy_function("range_arb_bot"),
-            "stat_arb_bot": _get_strategy_function("stat_arb_bot"),
-            "momentum_exploiter": _get_strategy_function("momentum_exploiter"),
-            "arbitrage_engine": _get_strategy_function("arbitrage_engine"),
-        })
-    
+
+    _ensure_strategy_map()
     return _STRATEGY_FN_MAP.get(name)
+
+
+_ensure_strategy_map()
 
 
 def _load() -> Dict[str, Dict[str, List[dict]]]:

--- a/crypto_bot/strategy/base.py
+++ b/crypto_bot/strategy/base.py
@@ -1,0 +1,194 @@
+"""Common strategy interfaces and helpers.
+
+This module centralises the callable contract used across the various
+strategy implementations.  Historically each strategy only exposed a module
+level :func:`generate_signal`.  The trading pipeline and selectors rely on
+that callable, but different modules gradually added small variations (extra
+hooks, wrapper classes, etc.).
+
+To make this contract explicit we now provide :class:`StrategyBase` and a
+runtime protocol that downstream consumers can rely on.  Strategies can
+subclass :class:`StrategyBase` to take advantage of the shared hooks, while
+existing function based implementations can be adapted using
+:class:`FunctionStrategy` or :class:`ModuleStrategyAdapter`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from types import ModuleType
+from typing import Any, Callable, Optional, Protocol, Tuple, runtime_checkable
+
+SignalResult = Tuple[float, str]
+"""The normalised signal output ``(score, direction)``."""
+
+StrategyCallable = Callable[..., SignalResult]
+"""Callable signature every strategy implementation must provide."""
+
+
+class StrategyBase(ABC):
+    """Base class for stateful strategy implementations.
+
+    Sub-classes only need to expose a :pyattr:`generate_signal` property that
+    returns a callable following :data:`StrategyCallable`.  The base class
+    exposes ``preprocess``/``postprocess`` hooks so strategies can override
+    shared behaviour without re-implementing the entire call pipeline.
+    """
+
+    name: Optional[str] = None
+    """Human readable name for the strategy."""
+
+    regime_filter: Any = None
+    """Optional regime filter attached to the strategy."""
+
+    def __init__(self, name: Optional[str] = None, regime_filter: Any = None) -> None:
+        if name is not None:
+            self.name = name
+        elif self.name is None:
+            # Fallback to class name if nothing explicit was provided.
+            self.name = self.__class__.__name__
+
+        if regime_filter is not None:
+            self.regime_filter = regime_filter
+
+    def preprocess(self, market_data: Any, *args: Any, **kwargs: Any) -> Any:
+        """Hook executed before :func:`generate_signal`.
+
+        The default implementation simply forwards the received ``market_data``
+        as strategies historically expected to operate on pandas DataFrames.
+        Implementations can override this hook to perform lightweight
+        transformations (e.g. column validation, symbol filtering).
+        """
+
+        return market_data
+
+    def postprocess(
+        self, result: SignalResult, *args: Any, **kwargs: Any
+    ) -> SignalResult:
+        """Hook executed after :func:`generate_signal`.
+
+        Returning the result unchanged keeps behaviour identical to the
+        historical function based implementations.
+        """
+
+        return result
+
+    def signal(self, market_data: Any, *args: Any, **kwargs: Any) -> SignalResult:
+        """Evaluate the strategy for ``market_data``.
+
+        ``signal`` mirrors the legacy helper that several pipelines expect.
+        The method delegates to :meth:`preprocess`, the callable returned by
+        :pyattr:`generate_signal` and finally :meth:`postprocess`.
+        """
+
+        processed = self.preprocess(market_data, *args, **kwargs)
+        signal_fn = self.generate_signal
+        result = signal_fn(processed, *args, **kwargs)
+        return self.postprocess(result, *args, **kwargs)
+
+    def __call__(self, market_data: Any, *args: Any, **kwargs: Any) -> SignalResult:
+        """Alias to :meth:`signal` so strategies remain directly callable."""
+
+        return self.signal(market_data, *args, **kwargs)
+
+    @property  # type: ignore[misc]
+    @abstractmethod
+    def generate_signal(self) -> StrategyCallable:
+        """Return the underlying signal generator callable."""
+
+
+@runtime_checkable
+class StrategyProtocol(Protocol):
+    """Runtime protocol used by loaders to type-check strategies."""
+
+    name: Optional[str]
+    regime_filter: Any
+
+    @property
+    def generate_signal(self) -> StrategyCallable:  # pragma: no cover - protocol
+        ...
+
+    def signal(self, market_data: Any, *args: Any, **kwargs: Any) -> SignalResult:
+        ...
+
+    def __call__(self, market_data: Any, *args: Any, **kwargs: Any) -> SignalResult:
+        ...
+
+
+class FunctionStrategy(StrategyBase):
+    """Strategy wrapper around a plain callable."""
+
+    def __init__(
+        self,
+        name: str,
+        fn: StrategyCallable,
+        regime_filter: Any = None,
+    ) -> None:
+        super().__init__(name=name, regime_filter=regime_filter)
+        self._fn = fn
+
+    @property
+    def generate_signal(self) -> StrategyCallable:
+        return self._fn
+
+
+class ModuleStrategyAdapter(FunctionStrategy):
+    """Adapter exposing a module level strategy through :class:`StrategyBase`."""
+
+    def __init__(self, name: str, module: ModuleType) -> None:
+        try:
+            fn = getattr(module, "generate_signal")
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise TypeError(
+                f"Module {module.__name__!r} does not expose generate_signal"
+            ) from exc
+
+        super().__init__(
+            name=name,
+            fn=fn,
+            regime_filter=getattr(module, "regime_filter", None),
+        )
+        self._module = module
+
+    def __getattr__(self, item: str) -> Any:
+        # Delegate attribute access to the underlying module so that existing
+        # code accessing helpers (e.g. cached stats, constants) keeps working.
+        return getattr(self._module, item)
+
+    def __dir__(self) -> list[str]:  # pragma: no cover - convenience
+        return sorted(set(super().__dir__()) | set(dir(self._module)))
+
+
+def ensure_strategy(name: str, candidate: Any) -> StrategyProtocol:
+    """Return a :class:`StrategyProtocol` adapter for ``candidate``.
+
+    ``candidate`` can be a module, a ``Strategy`` instance or any object that
+    already implements the protocol.  The helper keeps behaviour backwards
+    compatible by falling back to :class:`ModuleStrategyAdapter` when the
+    legacy module exposes a ``generate_signal`` function.
+    """
+
+    if isinstance(candidate, StrategyProtocol):
+        return candidate
+
+    strategy_cls = getattr(candidate, "Strategy", None)
+    if callable(strategy_cls):
+        try:
+            strategy = strategy_cls()
+        except Exception:  # pragma: no cover - instantiation failures
+            strategy = None
+        if isinstance(strategy, StrategyProtocol):
+            return strategy
+
+    if isinstance(candidate, ModuleType):
+        return ModuleStrategyAdapter(name, candidate)
+
+    fn = getattr(candidate, "generate_signal", None)
+    if callable(fn):
+        return FunctionStrategy(
+            name=name,
+            fn=fn,
+            regime_filter=getattr(candidate, "regime_filter", None),
+        )
+
+    raise TypeError(f"Object {candidate!r} does not implement the strategy interface")

--- a/crypto_bot/strategy/dca_bot.py
+++ b/crypto_bot/strategy/dca_bot.py
@@ -2,6 +2,8 @@ from typing import Optional, Tuple
 
 import pandas as pd
 
+from crypto_bot.strategy.base import FunctionStrategy
+
 
 def generate_signal(df: pd.DataFrame, config: Optional[dict] = None) -> Tuple[float, str]:
     """Simple dollar-cost averaging signal."""
@@ -20,3 +22,9 @@ class regime_filter:
     @staticmethod
     def matches(regime: str) -> bool:
         return True
+
+
+Strategy = FunctionStrategy("dca_bot", generate_signal, regime_filter)
+
+
+__all__ = ["generate_signal", "regime_filter", "Strategy"]

--- a/crypto_bot/strategy/momentum_bot.py
+++ b/crypto_bot/strategy/momentum_bot.py
@@ -8,6 +8,8 @@ from crypto_bot.utils.volatility import normalize_score_by_volatility
 from crypto_bot.utils.ml_utils import init_ml_or_warn, load_model
 import numpy as np
 
+from crypto_bot.strategy.base import StrategyBase, StrategyCallable
+
 logger = logging.getLogger(__name__)
 
 NAME = "momentum_bot"
@@ -161,17 +163,21 @@ class regime_filter:
         return regime in {"trending", "volatile"}
 
 
-class Strategy:
-    """Strategy wrapper so :func:`load_strategies` can auto-register it."""
+_strategy_callable = generate_signal
+
+
+class Strategy(StrategyBase):
+    """Strategy wrapper leveraging :class:`StrategyBase`."""
+
+    name = NAME
+    regime_filter = regime_filter
 
     def __init__(self) -> None:
-        self.name = "momentum_bot"
-        self.generate_signal = generate_signal
-        self.regime_filter = regime_filter
+        super().__init__(name=self.name, regime_filter=self.regime_filter)
 
-    def signal(self, *args, **kwargs):
-        """Compatibility wrapper for pipelines expecting ``signal``."""
-        return self.generate_signal(*args, **kwargs)
+    @property
+    def generate_signal(self) -> StrategyCallable:
+        return _strategy_callable
 
 
 __all__ = ["generate_signal", "regime_filter", "Strategy"]


### PR DESCRIPTION
## Summary
- introduce `StrategyBase` alongside helper adapters so function-based strategies can present a common protocol
- update the strategy package initialiser and loader utilities to rely on the shared strategy contract
- adapt representative strategies and selector utilities (momentum, DCA, router, meta selector) to the new interface

## Testing
- `pytest tests/test_strategy_router.py tests/test_meta_selector.py` *(fails: suite contains pre-existing expectation mismatches around strategy identity and async wrappers)*
- `pytest tests/test_trend_bot.py::test_long_signal_with_filters` *(fails: upstream strategy logic currently returns no signal for the synthetic data used in the test)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a4f868b88330b58f442ba7d7d905