### PR TITLE
Ensure sniper bot returns score-direction tuple with metadata

### DIFF
--- a/tests/test_sniper_price_fallback.py
+++ b/tests/test_sniper_price_fallback.py
@@ -20,10 +20,11 @@ def make_df():
 
 def test_price_fallback_long_signal():
     df = make_df()
-    score, direction, atr, event = sniper_bot.generate_signal(
+    score, direction = sniper_bot.generate_signal(
         df, {"price_fallback": True}
     )
+    metadata = getattr(sniper_bot.generate_signal, "last_metadata", {})
     assert direction == "long"
     assert score > 0
-    assert atr > 0
-    assert event
+    assert metadata["atr"] > 0
+    assert metadata["event"]


### PR DESCRIPTION
## Summary
- refactor `sniper_bot.generate_signal` to always return `(score, direction)` while storing ATR/event metadata on the call
- update sniper strategy tests to assert the two-element return shape and validate metadata in breakout and auto-short scenarios
- refresh fallback tests to consume the new metadata exposure

## Testing
- pytest tests/test_sniper_bot.py tests/test_sniper_price_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b33bfd24833091ecd8951b644c22