### PR TITLE
Fix volatility normalization usage and add regression tests

### DIFF
--- a/crypto_bot/strategy/momentum_exploiter.py
+++ b/crypto_bot/strategy/momentum_exploiter.py
@@ -241,7 +241,7 @@ def _detect_momentum_signals(
         'price_momentum': current['price_momentum']
     })
     
-    return signal_strength, signal_direction
+    return signal_strength, signal_direction, signal_metadata
 
 
 def generate_signal(
@@ -297,12 +297,13 @@ def generate_signal(
         return 0.0, "none"
     
     # Apply volatility normalization if enabled
-    if 'atr_pct' in metadata:
+    if signal_score > 0 and metadata.get('atr_pct') is not None:
         try:
             signal_score = normalize_score_by_volatility(
-                signal_score, metadata['atr_pct']
+                df,
+                signal_score
             )
-        except:
+        except Exception:
             pass  # Continue without normalization if it fails
     
     # Ensure signal score is within bounds

--- a/crypto_bot/strategy/ultra_scalp_bot.py
+++ b/crypto_bot/strategy/ultra_scalp_bot.py
@@ -269,12 +269,13 @@ def generate_signal(
         return 0.0, "none"
     
     # Apply volatility normalization if enabled
-    if 'atr_pct' in metadata:
+    if signal_score > 0 and metadata.get('atr_pct') is not None:
         try:
             signal_score = normalize_score_by_volatility(
-                signal_score, metadata['atr_pct']
+                df,
+                signal_score
             )
-        except:
+        except Exception:
             pass  # Continue without normalization if it fails
     
     # Ensure signal score is within bounds

--- a/crypto_bot/strategy/volatility_harvester.py
+++ b/crypto_bot/strategy/volatility_harvester.py
@@ -343,12 +343,13 @@ def generate_signal(
         return 0.0, "none"
     
     # Apply volatility normalization if enabled
-    if 'atr_pct' in metadata:
+    if signal_score > 0 and metadata.get('atr_pct') is not None:
         try:
             signal_score = normalize_score_by_volatility(
-                signal_score, metadata['atr_pct']
+                df,
+                signal_score
             )
-        except:
+        except Exception:
             pass  # Continue without normalization if it fails
     
     # Ensure signal score is within bounds

--- a/tests/test_momentum_exploiter.py
+++ b/tests/test_momentum_exploiter.py
@@ -1,0 +1,76 @@
+import importlib
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+
+MOMENTUM_MODULE = importlib.import_module("crypto_bot.strategy.momentum_exploiter")
+
+NORMALIZATION_CONFIG = {
+    "lookback": 20,
+    "momentum_window": 8,
+    "volume_zscore_threshold": -1.0,
+    "threshold": 0.0,
+    "min_atr_pct": 0.0001,
+    "momentum_threshold": 0.002,
+    "acceleration_threshold": 0.0005,
+    "rsi_window": 8,
+}
+
+
+def _build_momentum_frame(factor: float) -> pd.DataFrame:
+    periods = 120
+    index = pd.date_range("2024-01-01", periods=periods, freq="min")
+
+    close = 100 + np.linspace(0, 8, periods)
+    close[-30:] += np.linspace(0, 10, 30)
+    open_ = np.concatenate(([close[0]], close[:-1]))
+
+    range_base = np.full(periods, 0.6)
+    range_base[-20:] = range_base[-20:] * factor
+    high = close + range_base
+    low = close - range_base
+
+    volume = np.full(periods, 700.0)
+    volume += np.linspace(0, 80, periods)
+    volume[-10:] += np.linspace(150, 450, 10)
+
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+
+
+def _score_without_normalization(df: pd.DataFrame) -> tuple[float, str]:
+    with patch.object(
+        MOMENTUM_MODULE,
+        "normalize_score_by_volatility",
+        side_effect=lambda data, score, *args, **kwargs: score,
+    ):
+        return MOMENTUM_MODULE.generate_signal(df, config=NORMALIZATION_CONFIG)
+
+
+def test_momentum_exploiter_normalization_responds_to_volatility():
+    low_df = _build_momentum_frame(0.5)
+    high_df = _build_momentum_frame(2.0)
+
+    raw_low, dir_low_raw = _score_without_normalization(low_df)
+    raw_high, dir_high_raw = _score_without_normalization(high_df)
+
+    score_low, dir_low = MOMENTUM_MODULE.generate_signal(low_df, config=NORMALIZATION_CONFIG)
+    score_high, dir_high = MOMENTUM_MODULE.generate_signal(high_df, config=NORMALIZATION_CONFIG)
+
+    assert dir_low_raw == dir_high_raw == "long"
+    assert dir_low == dir_high == "long"
+
+    assert abs(raw_low - raw_high) < 1e-6
+    assert score_low < raw_low
+    assert score_high > raw_high
+    assert score_high > score_low

--- a/tests/test_ultra_scalp_bot.py
+++ b/tests/test_ultra_scalp_bot.py
@@ -1,0 +1,72 @@
+import importlib
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+
+ULTRA_MODULE = importlib.import_module("crypto_bot.strategy.ultra_scalp_bot")
+
+NORMALIZATION_CONFIG = {
+    "min_score": 0.0,
+    "volume_window": 6,
+    "min_volume_zscore": -2.0,
+    "min_atr_pct": 0.0001,
+    "atr_window": 5,
+}
+
+
+def _build_scalp_frame(factor: float) -> pd.DataFrame:
+    periods = 120
+    index = pd.date_range("2024-01-01", periods=periods, freq="min")
+
+    close = 100 + np.linspace(0, 3, periods)
+    close[-15:] += np.linspace(0, 4, 15)
+    open_ = np.concatenate(([close[0]], close[:-1]))
+
+    range_base = np.full(periods, 0.4)
+    range_base[-20:] = range_base[-20:] * factor
+    high = close + range_base
+    low = close - range_base
+
+    volume = np.full(periods, 900.0)
+    volume += np.linspace(0, 60, periods)
+    volume[-8:] += np.linspace(150, 300, 8)
+
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+
+
+def _score_without_normalization(df: pd.DataFrame) -> tuple[float, str]:
+    with patch.object(
+        ULTRA_MODULE,
+        "normalize_score_by_volatility",
+        side_effect=lambda data, score, *args, **kwargs: score,
+    ):
+        return ULTRA_MODULE.generate_signal(df, config=NORMALIZATION_CONFIG)
+
+
+def test_ultra_scalp_bot_normalization_boosts_high_volatility_scores():
+    low_df = _build_scalp_frame(0.4)
+    high_df = _build_scalp_frame(2.0)
+
+    raw_low, dir_low_raw = _score_without_normalization(low_df)
+    raw_high, dir_high_raw = _score_without_normalization(high_df)
+
+    score_low, dir_low = ULTRA_MODULE.generate_signal(low_df, config=NORMALIZATION_CONFIG)
+    score_high, dir_high = ULTRA_MODULE.generate_signal(high_df, config=NORMALIZATION_CONFIG)
+
+    assert dir_low_raw == dir_high_raw == "short"
+    assert dir_low == dir_high == "short"
+
+    assert score_low < raw_low
+    assert score_high > raw_high
+    assert score_high > score_low

--- a/tests/test_volatility_harvester.py
+++ b/tests/test_volatility_harvester.py
@@ -1,7 +1,13 @@
+import importlib
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 
 from crypto_bot.strategy import volatility_harvester
+
+
+VOLATILITY_MODULE = importlib.import_module("crypto_bot.strategy.volatility_harvester")
 
 
 TEST_CONFIG = {
@@ -64,3 +70,69 @@ def test_volatility_harvester_breakdown_short_signal():
 
     assert direction == "short"
     assert score > 0
+
+
+NORMALIZATION_CONFIG = {
+    "atr_threshold": 0.0003,
+    "atr_multiplier": 5.0,
+    "volume_zscore_threshold": 10.0,
+    "volume_spike": 10.0,
+    "range_expansion_threshold": 5.0,
+    "min_price_change": 0.0001,
+}
+
+
+def _build_normalization_frame(factor: float) -> pd.DataFrame:
+    periods = 120
+    index = pd.date_range("2024-01-01", periods=periods, freq="min")
+
+    close = 100 + np.linspace(0, 1.5, periods)
+    close[-15:] += np.linspace(0, 3, 15)
+    open_ = np.concatenate(([close[0]], close[:-1]))
+
+    base_range = np.full(periods, 0.8)
+    base_range[-20:] = base_range[-20:] * factor
+    high = close + base_range
+    low = close - base_range
+
+    volume = np.full(periods, 600.0)
+    volume += np.linspace(0, 20, periods)
+    volume[-5:] += np.linspace(120, 200, 5)
+
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+
+
+def _score_without_normalization(df: pd.DataFrame) -> tuple[float, str]:
+    with patch.object(
+        VOLATILITY_MODULE,
+        "normalize_score_by_volatility",
+        side_effect=lambda data, score, *args, **kwargs: score,
+    ):
+        return VOLATILITY_MODULE.generate_signal(df, config=NORMALIZATION_CONFIG)
+
+
+def test_volatility_harvester_normalization_scales_with_atr():
+    low_df = _build_normalization_frame(0.25)
+    high_df = _build_normalization_frame(2.0)
+
+    raw_low, dir_low_raw = _score_without_normalization(low_df)
+    raw_high, dir_high_raw = _score_without_normalization(high_df)
+
+    score_low, dir_low = VOLATILITY_MODULE.generate_signal(low_df, config=NORMALIZATION_CONFIG)
+    score_high, dir_high = VOLATILITY_MODULE.generate_signal(high_df, config=NORMALIZATION_CONFIG)
+
+    assert dir_low_raw == dir_high_raw == "long"
+    assert dir_low == dir_high == "long"
+
+    assert score_low < raw_low
+    assert score_high > raw_high
+    assert score_high > score_low


### PR DESCRIPTION
## Summary
- update volatility_harvester, momentum_exploiter, and ultra_scalp_bot to pass OHLCV data into the volatility normalization helper
- ensure the momentum exploiter returns metadata and add deterministic volatility-scaling tests for the three strategies

## Testing
- pytest tests/test_volatility_harvester.py tests/test_momentum_exploiter.py tests/test_ultra_scalp_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b3473c988330bbd8294397f14b5e