### PR TITLE
Ensure short history regime fallback yields neutral confidence

### DIFF
--- a/crypto_bot/regime/regime_classifier.py
+++ b/crypto_bot/regime/regime_classifier.py
@@ -16,6 +16,11 @@ from crypto_bot.utils.logger import LOG_DIR, setup_logger
 
 CONFIG_PATH = Path(__file__).with_name("regime_config.yaml")
 
+# Confidence score returned when there is not enough history to classify the
+# regime reliably. Chosen to be neutral but non-zero so downstream consumers do
+# not treat the result as a hard veto.
+SHORT_HISTORY_CONFIDENCE: float = 0.5
+
 
 def _load_config(path: Path) -> dict:
     with open(path, "r") as f:
@@ -465,7 +470,7 @@ def classify_regime(
     ml_min_bars = cfg.get("ml_min_bars", 20)
 
     if df_map is None and (df is None or len(df) < ml_min_bars):
-        return "unknown", set()
+        return "unknown", SHORT_HISTORY_CONFIDENCE
 
     result = _classify_all(df, higher_df, cfg, df_map=df_map)
 


### PR DESCRIPTION
## Summary
- add a reusable neutral short-history confidence constant and return it from the regime classifier fallback
- keep market analyzer confidence aggregation positive when the fallback emits scalars or empty sets
- update regime classifier tests for the new fallback payload and add coverage for analyzer behaviour on low history inputs

## Testing
- pytest tests/test_regime_classifier.py -k low_history_confidence_neutral -q

------
https://chatgpt.com/codex/tasks/task_e_68c9ba69f2f483309c56db98b302a5f8