### PR TITLE
Add lazy imports for grid bot helpers

### DIFF
--- a/crypto_bot/strategy/grid_bot.py
+++ b/crypto_bot/strategy/grid_bot.py
@@ -290,6 +290,8 @@ def generate_signal(
     breakout_range = (high - low) / 2
     breakout_threshold = breakout_range * cfg.breakout_mult
     if price > centre + breakout_threshold or price < centre - breakout_threshold:
+        from . import breakout_bot
+
         result = breakout_bot.generate_signal(df, _as_dict(config), higher_df)
         # breakout_bot returns (score, direction, atr) when higher_df is None
         # or (score, direction) when higher_df is provided
@@ -306,6 +308,8 @@ def generate_signal(
         near_lower = price - lower_bound <= grid_step
         near_upper = upper_bound - price <= grid_step
         if (near_lower or near_upper) and {"open", "high", "low", "close"}.issubset(df.columns):
+            from . import micro_scalp_bot
+
             scalp_score, scalp_dir = micro_scalp_bot.generate_signal(
                 df,
                 _as_dict(config),


### PR DESCRIPTION
## Summary
- add local imports for breakout and micro scalp helpers inside grid bot signal generation to avoid circular dependencies

## Testing
- python - <<'PY' (simulate breakout branch and ensure helper call) 
- python - <<'PY' (simulate dynamic grid scalp branch and ensure helper call)


------
https://chatgpt.com/codex/tasks/task_e_68c9d32fb0b0833092a0f47b65f77ce7