### PR TITLE
Add trading engine service scaffolding

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Build Trading Engine
         uses: docker/build-push-action@v5
         with:
-          context: ./services/trading_engine
+          context: .
+          file: services/trading_engine/Dockerfile
           push: false
           tags: legacy-coin-trader/trading-engine:latest
           cache-from: type=gha

--- a/crypto_bot/phase_runner.py
+++ b/crypto_bot/phase_runner.py
@@ -9,6 +9,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+from services.interface_layer.cycle import TradingCycleInterface
+
+
 @dataclass
 class BotContext:
     """Shared state for bot phases with enhanced memory management."""
@@ -206,26 +209,9 @@ class PhaseRunner:
 
     def __init__(self, phases: Iterable[Callable[[BotContext], Awaitable[None]]]):
         self.phases = list(phases)
+        self._cycle_interface = TradingCycleInterface(self.phases)
 
     async def run(self, ctx: BotContext) -> Dict[str, float]:
-        timings: Dict[str, float] = {}
-        
-        for phase in self.phases:
-            start = time.perf_counter()
-            
-            # Monitor memory during phase execution
-            if ctx.memory_manager:
-                with ctx.memory_manager.memory_monitoring(f"phase_{phase.__name__}"):
-                    await phase(ctx)
-            else:
-                await phase(ctx)
-            
-            timings[phase.__name__] = time.perf_counter() - start
-            
-            # Perform memory maintenance after each phase
-            if ctx.memory_manager:
-                maintenance_results = ctx.perform_memory_maintenance()
-                if maintenance_results.get("memory_pressure"):
-                    logger.warning(f"Memory pressure detected during {phase.__name__}")
-        
-        return timings
+        self._cycle_interface.set_phases(self.phases)
+        result = await self._cycle_interface.run_cycle(ctx)
+        return result.timings

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,8 @@ services:
       - TRADING_ENGINE_LOG_LEVEL=DEBUG
       - TRADING_ENGINE_CYCLE_INTERVAL=300  # Slower cycles for development
     volumes:
-      - ./services/trading_engine:/app
+      - ./services/trading_engine:/app/services/trading_engine
+      - ./services/interface_layer:/app/services/interface_layer
       - /app/__pycache__
 
   market-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,7 +29,8 @@ services:
       - TRADING_ENGINE_CYCLE_INTERVAL=30  # Faster cycles for testing
       - TRADING_ENGINE_BATCH_SIZE=10
     volumes:
-      - ./services/trading_engine:/app
+      - ./services/trading_engine:/app/services/trading_engine
+      - ./services/interface_layer:/app/services/interface_layer
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,9 @@ services:
 
   # Trading Engine - Core orchestration service
   trading-engine:
-    build: ./services/trading_engine
+    build:
+      context: .
+      dockerfile: services/trading_engine/Dockerfile
     ports:
       - "8001:8001"
     depends_on:
@@ -52,7 +54,8 @@ services:
       - TRADING_ENGINE_API_GATEWAY_HOST=api-gateway
       - TRADING_ENGINE_API_GATEWAY_PORT=8000
     volumes:
-      - ./services/trading_engine:/app
+      - ./services/trading_engine:/app/services/trading_engine
+      - ./services/interface_layer:/app/services/interface_layer
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
       interval: 30s

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service packages for LegacyCoinTrader microservices."""

--- a/services/interface_layer/__init__.py
+++ b/services/interface_layer/__init__.py
@@ -1,0 +1,5 @@
+"""Interface primitives shared across microservices."""
+
+from .cycle import CycleExecutionResult, PhaseCallable, TradingCycleInterface
+
+__all__ = ["TradingCycleInterface", "CycleExecutionResult", "PhaseCallable"]

--- a/services/interface_layer/cycle.py
+++ b/services/interface_layer/cycle.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Shared trading cycle orchestration primitives.
+
+This module provides a small interface layer that can be consumed by any
+service that needs to orchestrate trading cycles.  It encapsulates the core
+loop that was previously implemented directly in ``crypto_bot.phase_runner``
+and exposes a clean abstraction that returns structured results.
+"""
+
+import inspect
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+PhaseCallable = Callable[[Any], Awaitable[None]]
+
+
+@dataclass
+class CycleExecutionResult:
+    """Represents the outcome of a trading cycle execution."""
+
+    timings: Dict[str, float] = field(default_factory=dict)
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration(self) -> float:
+        """Return the total execution time for the cycle in seconds."""
+
+        if not self.completed_at or not self.started_at:
+            return 0.0
+        return (self.completed_at - self.started_at).total_seconds()
+
+
+class TradingCycleInterface:
+    """Execute a sequence of asynchronous phases and capture timings."""
+
+    def __init__(self, phases: Optional[Iterable[PhaseCallable]] = None) -> None:
+        self._phases: List[PhaseCallable] = list(phases or [])
+
+    @property
+    def phases(self) -> List[PhaseCallable]:
+        """Return the configured phases."""
+
+        return list(self._phases)
+
+    def set_phases(self, phases: Iterable[PhaseCallable]) -> None:
+        """Replace the configured phases with ``phases``."""
+
+        self._phases = list(phases)
+
+    async def run_cycle(
+        self,
+        ctx: Any,
+        phases: Optional[Iterable[PhaseCallable]] = None,
+    ) -> CycleExecutionResult:
+        """Execute ``phases`` using ``ctx`` and return execution timings."""
+
+        phase_sequence = list(phases or self._phases)
+        if not phase_sequence:
+            raise ValueError("No phases configured for trading cycle execution")
+
+        result = CycleExecutionResult()
+        result.started_at = datetime.now(timezone.utc)
+        overall_start = time.perf_counter()
+
+        for phase in phase_sequence:
+            phase_name = getattr(phase, "__name__", "unknown_phase")
+            start_time = time.perf_counter()
+
+            memory_manager = getattr(ctx, "memory_manager", None)
+            monitor = getattr(memory_manager, "memory_monitoring", None)
+
+            try:
+                if monitor:
+                    with monitor(f"phase_{phase_name}"):
+                        await phase(ctx)
+                else:
+                    await phase(ctx)
+            except Exception:
+                logger.exception("Trading cycle phase %s failed", phase_name)
+                raise
+            finally:
+                result.timings[phase_name] = time.perf_counter() - start_time
+
+            maintenance_result: Optional[Dict[str, Any]] = None
+            if hasattr(ctx, "perform_memory_maintenance"):
+                try:
+                    maintenance = ctx.perform_memory_maintenance()
+                    if inspect.isawaitable(maintenance):
+                        maintenance = await maintenance  # type: ignore[assignment]
+                    if isinstance(maintenance, dict):
+                        maintenance_result = maintenance
+                except Exception:  # pragma: no cover - defensive logging
+                    logger.debug("Memory maintenance failed after %s", phase_name, exc_info=True)
+
+            if maintenance_result and maintenance_result.get("memory_pressure"):
+                logger.warning("Memory pressure detected during %s", phase_name)
+
+        result.completed_at = datetime.now(timezone.utc)
+        result.metadata["duration_seconds"] = time.perf_counter() - overall_start
+        return result
+
+
+__all__ = ["TradingCycleInterface", "CycleExecutionResult", "PhaseCallable"]

--- a/services/trading_engine/Dockerfile
+++ b/services/trading_engine/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY services/trading_engine/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY services /app/services
+COPY crypto_bot /app/crypto_bot
+
+WORKDIR /app/services/trading_engine
+ENV PYTHONPATH=/app
+
+EXPOSE 8001
+
+CMD ["uvicorn", "services.trading_engine.app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/trading_engine/__init__.py
+++ b/services/trading_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Trading engine service package."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/trading_engine/config.py
+++ b/services/trading_engine/config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Runtime configuration for the trading engine service."""
+
+from functools import lru_cache
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="TRADING_ENGINE_", env_file=None)
+
+    app_name: str = Field(default="trading-engine-service")
+    host: str = Field(default="0.0.0.0")
+    port: int = Field(default=8001)
+
+    redis_host: str = Field(default="localhost")
+    redis_port: int = Field(default=6379)
+    redis_db: int = Field(default=0)
+    redis_use_ssl: bool = Field(default=False)
+
+    default_cycle_interval: int = Field(default=60, ge=1)
+    state_key_prefix: str = Field(default="trading_engine")
+
+    log_level: str = Field(default="INFO")
+    cycle_timeout_seconds: Optional[int] = Field(default=900, ge=1)
+
+    def redis_dsn(self) -> str:
+        protocol = "rediss" if self.redis_use_ssl else "redis"
+        return f"{protocol}://{self.redis_host}:{self.redis_port}/{self.redis_db}"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached ``Settings`` instance."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/services/trading_engine/interface.py
+++ b/services/trading_engine/interface.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Adaptor that bridges the trading engine service with the shared interface."""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+from services.interface_layer.cycle import CycleExecutionResult, TradingCycleInterface
+
+from .phases import DEFAULT_PHASES
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CycleContext:
+    """Minimal context passed to cycle phases."""
+
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    timing: Dict[str, float] = field(default_factory=dict)
+    memory_manager: Optional[Any] = None
+
+    def perform_memory_maintenance(self) -> Dict[str, Any]:  # pragma: no cover - simple stub
+        return {}
+
+
+class TradingEngineInterface:
+    """High-level orchestration entry point for trading cycles."""
+
+    def __init__(self, phases: Optional[Iterable] = None) -> None:
+        self._phases = list(phases or DEFAULT_PHASES)
+        self._runner = TradingCycleInterface(self._phases)
+
+    def set_phases(self, phases: Iterable) -> None:
+        self._phases = list(phases)
+        self._runner.set_phases(self._phases)
+
+    async def run_cycle(self, metadata: Optional[Dict[str, Any]] = None) -> CycleExecutionResult:
+        """Execute a single trading cycle and return timing information."""
+
+        context = CycleContext(metadata=dict(metadata or {}))
+        result = await self._runner.run_cycle(context)
+        context.timing = result.timings
+        logger.debug("Trading cycle completed with timings: %s", result.timings)
+        return result
+
+
+__all__ = ["TradingEngineInterface", "CycleContext"]

--- a/services/trading_engine/main.py
+++ b/services/trading_engine/main.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Entrypoint for running the trading engine service locally."""
+
+import uvicorn
+
+from .app import app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    uvicorn.run("services.trading_engine.app:app", host="0.0.0.0", port=8001, reload=False)

--- a/services/trading_engine/phases.py
+++ b/services/trading_engine/phases.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Default phases executed by the trading engine service."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .interface import CycleContext
+
+
+async def prepare_cycle(context: "CycleContext") -> None:
+    """Record that a new cycle is being prepared."""
+
+    context.metadata.setdefault("events", []).append("prepare")
+    await asyncio.sleep(0)
+    logger.debug("Prepared trading cycle with metadata: %s", context.metadata)
+
+
+async def orchestrate_cycle(context: "CycleContext") -> None:
+    """Simulate orchestration work for the trading cycle."""
+
+    context.metadata["cycle_started_at"] = datetime.now(timezone.utc).isoformat()
+    await asyncio.sleep(0)
+    logger.debug("Orchestrated trading cycle")
+
+
+async def finalize_cycle(context: "CycleContext") -> None:
+    """Finalize the trading cycle and mark completion time."""
+
+    context.metadata["cycle_completed_at"] = datetime.now(timezone.utc).isoformat()
+    await asyncio.sleep(0)
+    logger.debug("Finalized trading cycle")
+
+
+DEFAULT_PHASES = [prepare_cycle, orchestrate_cycle, finalize_cycle]
+
+
+__all__ = [
+    "prepare_cycle",
+    "orchestrate_cycle",
+    "finalize_cycle",
+    "DEFAULT_PHASES",
+]

--- a/services/trading_engine/redis_state.py
+++ b/services/trading_engine/redis_state.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+"""Redis-backed persistence for trading cycle state."""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from redis.asyncio import Redis
+
+from services.interface_layer.cycle import CycleExecutionResult
+
+
+@dataclass
+class CycleState:
+    """Lightweight representation of scheduler state."""
+
+    running: bool = False
+    interval_seconds: int = 60
+    next_run_at: Optional[datetime] = None
+    last_run_started_at: Optional[datetime] = None
+    last_run_completed_at: Optional[datetime] = None
+    last_timings: Dict[str, float] = field(default_factory=dict)
+    last_error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def _dt_to_iso(value: Optional[datetime]) -> Optional[str]:
+        if value is None:
+            return None
+        return value.astimezone(timezone.utc).isoformat()
+
+    @staticmethod
+    def _iso_to_dt(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        return datetime.fromisoformat(value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "running": self.running,
+            "interval_seconds": self.interval_seconds,
+            "next_run_at": self._dt_to_iso(self.next_run_at),
+            "last_run_started_at": self._dt_to_iso(self.last_run_started_at),
+            "last_run_completed_at": self._dt_to_iso(self.last_run_completed_at),
+            "last_timings": self.last_timings,
+            "last_error": self.last_error,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CycleState":
+        return cls(
+            running=bool(data.get("running", False)),
+            interval_seconds=int(data.get("interval_seconds", 60)),
+            next_run_at=cls._iso_to_dt(data.get("next_run_at")),
+            last_run_started_at=cls._iso_to_dt(data.get("last_run_started_at")),
+            last_run_completed_at=cls._iso_to_dt(data.get("last_run_completed_at")),
+            last_timings=dict(data.get("last_timings", {})),
+            last_error=data.get("last_error"),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+    def predict_next_run(self) -> Optional[datetime]:
+        if not self.running or self.interval_seconds <= 0:
+            return None
+        reference = self.last_run_completed_at or datetime.now(timezone.utc)
+        return reference + timedelta(seconds=self.interval_seconds)
+
+
+class RedisCycleStateStore:
+    """Persist ``CycleState`` using Redis."""
+
+    def __init__(self, client: Redis, key_prefix: str = "trading_engine") -> None:
+        self._client = client
+        self._state_key = f"{key_prefix}:state"
+
+    async def load_state(self) -> CycleState:
+        raw = await self._client.get(self._state_key)
+        if not raw:
+            return CycleState()
+        payload = json.loads(raw)
+        return CycleState.from_dict(payload)
+
+    async def save_state(self, state: CycleState) -> CycleState:
+        await self._client.set(self._state_key, json.dumps(state.to_dict()))
+        return state
+
+    async def ensure_defaults(self, interval_seconds: int) -> CycleState:
+        state = await self.load_state()
+        if state.interval_seconds != interval_seconds and not state.running:
+            state.interval_seconds = interval_seconds
+        if state.next_run_at is None and state.running:
+            state.next_run_at = state.predict_next_run()
+        await self.save_state(state)
+        return state
+
+    async def update(self, **fields: Any) -> CycleState:
+        state = await self.load_state()
+        for key, value in fields.items():
+            if hasattr(state, key):
+                setattr(state, key, value)
+        await self.save_state(state)
+        return state
+
+    async def mark_cycle_start(self, started_at: datetime) -> CycleState:
+        return await self.update(last_run_started_at=started_at, last_error=None)
+
+    async def mark_cycle_complete(
+        self,
+        result: CycleExecutionResult,
+        completed_at: datetime,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CycleState:
+        state = await self.load_state()
+        state.last_timings = result.timings
+        state.last_run_completed_at = completed_at
+        state.last_error = None
+        state.last_run_started_at = state.last_run_started_at or completed_at
+        state.next_run_at = state.predict_next_run()
+        if metadata is not None:
+            state.metadata = dict(metadata)
+        await self.save_state(state)
+        return state
+
+    async def mark_cycle_failure(
+        self,
+        error: str,
+        completed_at: datetime,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CycleState:
+        update_fields: Dict[str, Any] = {"last_error": error, "last_run_completed_at": completed_at}
+        if metadata is not None:
+            update_fields["metadata"] = dict(metadata)
+        state = await self.update(**update_fields)
+        return state
+
+
+__all__ = ["CycleState", "RedisCycleStateStore"]

--- a/services/trading_engine/requirements.txt
+++ b/services/trading_engine/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.95.0,<0.101.0
+uvicorn[standard]>=0.21.0,<0.24.0
+redis>=4.3.0,<5.0.0
+pydantic>=2.0.0,<2.5.0
+pydantic-settings>=2.0.0,<2.1.0

--- a/services/trading_engine/scheduler.py
+++ b/services/trading_engine/scheduler.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""Async scheduler for orchestrating trading cycles."""
+
+import asyncio
+import contextlib
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from services.interface_layer.cycle import CycleExecutionResult
+
+from .interface import TradingEngineInterface
+from .redis_state import CycleState, RedisCycleStateStore
+
+logger = logging.getLogger(__name__)
+
+
+class CycleScheduler:
+    """Manage periodic execution of trading cycles."""
+
+    def __init__(
+        self,
+        interface: TradingEngineInterface,
+        state_store: RedisCycleStateStore,
+        default_interval: int,
+    ) -> None:
+        self._interface = interface
+        self._state_store = state_store
+        self._interval = max(default_interval, 1)
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        interval_seconds: Optional[int] = None,
+        immediate: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CycleState:
+        async with self._lock:
+            interval = int(interval_seconds or self._interval)
+            self._interval = max(interval, 1)
+
+            state = await self._state_store.load_state()
+            state.running = True
+            state.interval_seconds = self._interval
+            state.metadata = dict(metadata or {})
+            now = datetime.now(timezone.utc)
+            state.next_run_at = now if immediate else state.predict_next_run() or now
+            await self._state_store.save_state(state)
+
+            self._running = True
+            if self._task and not self._task.done():
+                self._task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._task
+            self._task = asyncio.create_task(self._run_loop(immediate))
+            logger.info("Trading cycle scheduler started with interval %s", self._interval)
+            return state
+
+    async def stop(self) -> CycleState:
+        async with self._lock:
+            self._running = False
+            if self._task:
+                self._task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._task
+                self._task = None
+            state = await self._state_store.update(running=False, next_run_at=None)
+            logger.info("Trading cycle scheduler stopped")
+            return state
+
+    async def run_once(self, metadata: Optional[Dict[str, Any]] = None) -> CycleExecutionResult:
+        metadata = dict(metadata or {})
+        started_at = datetime.now(timezone.utc)
+        await self._state_store.mark_cycle_start(started_at)
+        try:
+            result = await self._interface.run_cycle(metadata=metadata)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Trading cycle execution failed")
+            await self._state_store.mark_cycle_failure(
+                str(exc), datetime.now(timezone.utc), metadata=metadata
+            )
+            raise
+        completed_at = result.completed_at or datetime.now(timezone.utc)
+        state = await self._state_store.mark_cycle_complete(
+            result, completed_at, metadata=metadata
+        )
+        if state.running:
+            await self._state_store.update(next_run_at=state.predict_next_run())
+        return result
+
+    async def get_state(self) -> CycleState:
+        return await self._state_store.load_state()
+
+    async def shutdown(self) -> None:
+        try:
+            await self.stop()
+        finally:
+            self._task = None
+
+    async def _run_loop(self, immediate: bool) -> None:
+        try:
+            if immediate:
+                await self.run_once()
+            while self._running:
+                await asyncio.sleep(self._interval)
+                if not self._running:
+                    break
+                await self.run_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - background loop safety
+            logger.exception("Trading cycle loop crashed: %s", exc)
+        finally:
+            self._task = None
+
+
+__all__ = ["CycleScheduler"]

--- a/services/trading_engine/schemas.py
+++ b/services/trading_engine/schemas.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Pydantic models exposed by the trading engine API."""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+from .redis_state import CycleState
+
+
+class StartCycleRequest(BaseModel):
+    interval_seconds: Optional[int] = Field(default=None, ge=1)
+    immediate: bool = Field(default=False)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RunCycleResponse(BaseModel):
+    status: str
+    timings: Dict[str, float]
+    started_at: datetime
+    completed_at: datetime
+    duration: float
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CycleStateResponse(BaseModel):
+    running: bool
+    interval_seconds: int
+    next_run_at: Optional[datetime]
+    last_run_started_at: Optional[datetime]
+    last_run_completed_at: Optional[datetime]
+    last_timings: Dict[str, float] = Field(default_factory=dict)
+    last_error: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_state(cls, state: CycleState) -> "CycleStateResponse":
+        return cls(
+            running=state.running,
+            interval_seconds=state.interval_seconds,
+            next_run_at=state.next_run_at,
+            last_run_started_at=state.last_run_started_at,
+            last_run_completed_at=state.last_run_completed_at,
+            last_timings=state.last_timings,
+            last_error=state.last_error,
+            metadata=state.metadata,
+        )
+
+
+__all__ = ["StartCycleRequest", "RunCycleResponse", "CycleStateResponse"]


### PR DESCRIPTION
## Summary
- add a shared trading cycle interface to reuse PhaseRunner orchestration logic across services
- scaffold a FastAPI-based trading engine service with scheduling endpoints, Redis-backed state, and default phases
- update docker-compose configurations and CI build steps to include the new service container and shared interface package

## Testing
- pytest tests/test_position_monitoring_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68c9dd44cf2c83309d0653724de3339a