### PR TITLE
Allow injecting timing and randomness dependencies

### DIFF
--- a/services/trading_engine/interface.py
+++ b/services/trading_engine/interface.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Optional
+from datetime import datetime
+from typing import Any, Callable, Dict, Iterable, Optional
 
 from services.interface_layer.cycle import CycleExecutionResult, TradingCycleInterface
 
@@ -28,9 +29,15 @@ class CycleContext:
 class TradingEngineInterface:
     """High-level orchestration entry point for trading cycles."""
 
-    def __init__(self, phases: Optional[Iterable] = None) -> None:
+    def __init__(
+        self,
+        phases: Optional[Iterable] = None,
+        *,
+        clock: Optional[Callable[[], datetime]] = None,
+        timer: Optional[Callable[[], float]] = None,
+    ) -> None:
         self._phases = list(phases or DEFAULT_PHASES)
-        self._runner = TradingCycleInterface(self._phases)
+        self._runner = TradingCycleInterface(self._phases, clock=clock, timer=timer)
 
     def set_phases(self, phases: Iterable) -> None:
         self._phases = list(phases)


### PR DESCRIPTION
## Summary
- extend the shared TradingCycleInterface and trading-engine wrapper to accept optional clock and timer callables
- allow PhaseRunner and BotContext to work with injected timing hooks and seedable RNGs
- expose a public run_bot entrypoint that forwards optional clock/timer/RNG overrides while keeping defaults

## Testing
- pytest tests/test_position_monitoring_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68ca0c2c6efc8330a0baa10a6fff29ab