### PR TITLE
Introduce execution microservice with async adapter integration

### DIFF
--- a/crypto_bot/services/adapters/execution.py
+++ b/crypto_bot/services/adapters/execution.py
@@ -1,8 +1,16 @@
-"""In-process adapter for centralized exchange execution."""
+"""Adapter delegating trade execution to the execution microservice."""
 
 from __future__ import annotations
 
-from crypto_bot.execution.cex_executor import execute_trade_async, get_exchange
+import asyncio
+import json
+import logging
+from threading import Lock
+from typing import Any, Mapping
+
+from services.execution import ExecutionService as CoreExecutionService
+from services.execution import ExecutionServiceConfig, OrderRequest
+
 from crypto_bot.services.interfaces import (
     ExchangeRequest,
     ExchangeResponse,
@@ -11,25 +19,102 @@ from crypto_bot.services.interfaces import (
     TradeExecutionResponse,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class ExecutionAdapter(ExecutionService):
-    """Adapter for :mod:`crypto_bot.execution.cex_executor`."""
+    """Execution adapter backed by :mod:`services.execution`."""
+
+    def __init__(self) -> None:
+        self._services: dict[str, CoreExecutionService] = {}
+        self._lock = Lock()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _config_key(self, config: Mapping[str, Any] | None) -> str:
+        payload = json.dumps(dict(config or {}), sort_keys=True, default=str)
+        return payload
+
+    def _get_service(self, config: Mapping[str, Any] | None) -> CoreExecutionService:
+        key = self._config_key(config)
+        with self._lock:
+            service = self._services.get(key)
+            if service is None:
+                service = CoreExecutionService(ExecutionServiceConfig.from_mapping(config or {}))
+                # Ensure connectivity is established eagerly for deterministic errors
+                service.ensure_session()
+                self._services[key] = service
+        return service
+
+    # ------------------------------------------------------------------
+    # Protocol implementation
+    # ------------------------------------------------------------------
 
     def create_exchange(self, request: ExchangeRequest) -> ExchangeResponse:
-        exchange, ws_client = get_exchange(dict(request.config))
+        service = self._get_service(request.config)
+        exchange, ws_client = service.create_exchange()
         return ExchangeResponse(exchange=exchange, ws_client=ws_client)
 
     async def execute_trade(self, request: TradeExecutionRequest) -> TradeExecutionResponse:
-        order = await execute_trade_async(
-            request.exchange,
-            request.ws_client,
-            request.symbol,
-            request.side,
-            request.amount,
-            notifier=request.notifier,
-            dry_run=request.dry_run,
-            use_websocket=request.use_websocket,
-            config=dict(request.config or {}),
-            score=request.score,
-        )
-        return TradeExecutionResponse(order=order)
+        service = self._get_service(request.config)
+        client_order_id = service.generate_client_order_id()
+        ack_subscription = service.subscribe_acks()
+        fill_subscription = service.subscribe_fills()
+        try:
+            order_request = OrderRequest(
+                symbol=request.symbol,
+                side=request.side,
+                amount=request.amount,
+                client_order_id=client_order_id,
+                dry_run=request.dry_run,
+                use_websocket=request.use_websocket,
+                score=request.score,
+                config=dict(request.config or {}),
+                notifier=request.notifier,
+                metadata={"source": "crypto_bot"},
+            )
+            await service.submit_order(order_request)
+            ack = await self._await_ack(ack_subscription, client_order_id, request.config)
+            if not ack.accepted:
+                logger.warning("Order %s rejected: %s", client_order_id, ack.reason)
+                return TradeExecutionResponse(order={})
+            fill = await self._await_fill(fill_subscription, client_order_id, request.config)
+            if not fill.success or not fill.order:
+                logger.warning("Order %s failed: %s", client_order_id, fill.error)
+                return TradeExecutionResponse(order=fill.order or {})
+            return TradeExecutionResponse(order=fill.order)
+        finally:
+            ack_subscription.close()
+            fill_subscription.close()
+
+    # ------------------------------------------------------------------
+    # Event helpers
+    # ------------------------------------------------------------------
+
+    async def _await_ack(
+        self,
+        subscription,
+        client_order_id: str,
+        config: Mapping[str, Any] | None,
+    ):
+        timeout = float((config or {}).get("ack_timeout", 15.0))
+        while True:
+            ack = await asyncio.wait_for(subscription.get(), timeout=timeout)
+            if ack.client_order_id != client_order_id:
+                continue
+            return ack
+
+    async def _await_fill(
+        self,
+        subscription,
+        client_order_id: str,
+        config: Mapping[str, Any] | None,
+    ):
+        timeout = float((config or {}).get("fill_timeout", 60.0))
+        while True:
+            fill = await asyncio.wait_for(subscription.get(), timeout=timeout)
+            if fill.client_order_id != client_order_id:
+                continue
+            return fill

--- a/services/execution/__init__.py
+++ b/services/execution/__init__.py
@@ -1,0 +1,29 @@
+"""Execution microservice package."""
+
+from .config import (
+    CredentialsConfig,
+    ExecutionServiceConfig,
+    MonitoringConfig,
+    TelegramConfig,
+)
+from .models import (
+    OrderAck,
+    OrderFill,
+    OrderRequest,
+    SecretRef,
+)
+from .secrets import SecretLoader
+from .service import ExecutionService
+
+__all__ = [
+    "CredentialsConfig",
+    "ExecutionService",
+    "ExecutionServiceConfig",
+    "MonitoringConfig",
+    "OrderAck",
+    "OrderFill",
+    "OrderRequest",
+    "SecretLoader",
+    "SecretRef",
+    "TelegramConfig",
+]

--- a/services/execution/config.py
+++ b/services/execution/config.py
@@ -1,0 +1,127 @@
+"""Configuration dataclasses for the execution microservice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping, Optional
+
+from .models import SecretRef
+
+
+@dataclass(slots=True)
+class TelegramConfig:
+    """Settings controlling Telegram notifications."""
+
+    enabled: bool = False
+    token: Optional[SecretRef] = None
+    chat_id: Optional[SecretRef] = None
+    parse_mode: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | "TelegramConfig" | None) -> "TelegramConfig":
+        if isinstance(data, cls):
+            return data
+        data = data or {}
+        return cls(
+            enabled=bool(data.get("enabled", data.get("token"))),
+            token=SecretRef.from_value(data.get("token"), default_source="env"),
+            chat_id=SecretRef.from_value(data.get("chat_id"), default_source="literal"),
+            parse_mode=data.get("parse_mode"),
+        )
+
+
+@dataclass(slots=True)
+class MonitoringConfig:
+    """Settings controlling monitoring callbacks for order lifecycle events."""
+
+    enabled: bool = False
+    sink: str = "local"
+    extra_tags: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(
+        cls, data: Mapping[str, Any] | "MonitoringConfig" | None
+    ) -> "MonitoringConfig":
+        if isinstance(data, cls):
+            return data
+        data = data or {}
+        tags = data.get("extra_tags") or {}
+        if not isinstance(tags, Mapping):
+            raise TypeError("extra_tags must be a mapping of string keys")
+        return cls(
+            enabled=bool(data.get("enabled")),
+            sink=str(data.get("sink", "local")),
+            extra_tags=dict(tags),
+        )
+
+
+@dataclass(slots=True)
+class CredentialsConfig:
+    """References describing where to load exchange credentials."""
+
+    api_key: SecretRef
+    api_secret: SecretRef
+    passphrase: Optional[SecretRef] = None
+    ws_token: Optional[SecretRef] = None
+    api_token: Optional[SecretRef] = None
+
+    @classmethod
+    def from_mapping(
+        cls, data: Mapping[str, Any] | "CredentialsConfig" | None
+    ) -> Optional["CredentialsConfig"]:
+        if isinstance(data, cls):
+            return data
+        if data is None:
+            return None
+        if not isinstance(data, Mapping):
+            raise TypeError("credentials configuration must be a mapping")
+        api_key = SecretRef.from_value(data.get("api_key"))
+        api_secret = SecretRef.from_value(data.get("api_secret"))
+        if api_key is None or api_secret is None:
+            raise ValueError("api_key and api_secret must be provided for credentials")
+        return cls(
+            api_key=api_key,
+            api_secret=api_secret,
+            passphrase=SecretRef.from_value(data.get("passphrase")),
+            ws_token=SecretRef.from_value(data.get("ws_token")),
+            api_token=SecretRef.from_value(data.get("api_token")),
+        )
+
+
+@dataclass(slots=True)
+class ExecutionServiceConfig:
+    """Runtime configuration for :class:`services.execution.service.ExecutionService`."""
+
+    exchange: Mapping[str, Any] = field(default_factory=dict)
+    credentials: Optional[CredentialsConfig] = None
+    dry_run: bool = True
+    use_websocket: bool = False
+    ack_topic: str = "execution.acks"
+    fill_topic: str = "execution.fills"
+    idempotency_ttl: float = 3600.0
+    telegram: TelegramConfig = field(default_factory=TelegramConfig)
+    monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        base: Mapping[str, Any] | MutableMapping[str, Any] | "ExecutionServiceConfig" | None,
+    ) -> "ExecutionServiceConfig":
+        if isinstance(base, cls):
+            return base
+        config = dict(base or {})
+        telegram_cfg = TelegramConfig.from_mapping(config.get("telegram"))
+        monitoring_cfg = MonitoringConfig.from_mapping(config.get("monitoring"))
+        credentials_cfg = CredentialsConfig.from_mapping(config.get("credentials"))
+        dry_run = config.get("execution_mode", "dry_run") == "dry_run"
+        return cls(
+            exchange=config,
+            credentials=credentials_cfg,
+            dry_run=dry_run,
+            use_websocket=bool(config.get("use_websocket", False)),
+            ack_topic=str(config.get("ack_topic", "execution.acks")),
+            fill_topic=str(config.get("fill_topic", "execution.fills")),
+            idempotency_ttl=float(config.get("idempotency_ttl", 3600.0)),
+            telegram=telegram_cfg,
+            monitoring=monitoring_cfg,
+        )

--- a/services/execution/exchange.py
+++ b/services/execution/exchange.py
@@ -1,0 +1,68 @@
+"""Exchange connectivity utilities for the execution service."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+from typing import Any, Mapping
+
+from crypto_bot.execution.cex_executor import get_exchange
+
+from .models import ExchangeCredentials, ExchangeSession
+from .nonce import NonceManager
+from .secrets import SecretLoader
+
+
+@contextlib.contextmanager
+def _temporary_env(values: Mapping[str, str]):
+    """Temporarily set environment variables while creating an exchange."""
+    previous: dict[str, str | None] = {key: os.environ.get(key) for key in values}
+    try:
+        for key, value in values.items():
+            os.environ[key] = value
+        yield
+    finally:
+        for key, prior in previous.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
+
+
+def _hash_config(config: Mapping[str, Any]) -> str:
+    """Return a deterministic hash for ``config``."""
+
+    def _normalize(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(k): _normalize(v) for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+        if isinstance(value, (list, tuple)):
+            return [_normalize(v) for v in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return repr(value)
+
+    normalized = _normalize(config)
+    payload = json.dumps(normalized, sort_keys=True).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+class ExchangeFactory:
+    """Factory that creates and memoises exchange sessions."""
+
+    def __init__(self, secret_loader: SecretLoader) -> None:
+        self._secret_loader = secret_loader
+
+    def create_session(
+        self,
+        config: Mapping[str, Any],
+        credentials: ExchangeCredentials | None,
+        nonce_manager: NonceManager,
+    ) -> ExchangeSession:
+        env_values = self._secret_loader.to_env_mapping(credentials)
+        with _temporary_env(env_values):
+            exchange, ws_client = get_exchange(dict(config))
+        if hasattr(exchange, "nonce"):
+            exchange.nonce = nonce_manager.next_nonce  # type: ignore[assignment]
+        return ExchangeSession(exchange=exchange, ws_client=ws_client, config_hash=_hash_config(config))

--- a/services/execution/message_bus.py
+++ b/services/execution/message_bus.py
@@ -1,0 +1,68 @@
+"""Light-weight asynchronous message topics used for order events."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Generic, Iterable, Optional, Set, TypeVar
+
+T = TypeVar("T")
+
+
+class TopicSubscription(Generic[T]):
+    """Handle used by consumers to receive messages from a topic."""
+
+    def __init__(self, topic: "AsyncTopic[T]", queue: "asyncio.Queue[T]") -> None:
+        self._topic = topic
+        self._queue = queue
+        self._closed = False
+
+    async def get(self) -> T:
+        """Return the next message, blocking until one is available."""
+        return await self._queue.get()
+
+    def close(self) -> None:
+        """Unsubscribe the consumer from the topic."""
+        if not self._closed:
+            self._topic._unsubscribe(self._queue)
+            self._closed = True
+
+    def __aiter__(self):  # pragma: no cover - convenience iterator
+        return self
+
+    async def __anext__(self):  # pragma: no cover - convenience iterator
+        try:
+            return await self.get()
+        except asyncio.CancelledError as exc:
+            self.close()
+            raise StopAsyncIteration from exc
+
+
+class AsyncTopic(Generic[T]):
+    """Publish/subscribe primitive backed by asyncio queues."""
+
+    def __init__(self, *, max_queue: int = 0) -> None:
+        self._subscribers: Set[asyncio.Queue[T]] = set()
+        self._max_queue = max_queue
+        self._lock = asyncio.Lock()
+
+    async def publish(self, message: T) -> None:
+        """Publish ``message`` to all subscribers."""
+        async with self._lock:
+            queues: Iterable[asyncio.Queue[T]] = list(self._subscribers)
+        for queue in queues:
+            try:
+                queue.put_nowait(message)
+            except asyncio.QueueFull:  # pragma: no cover - defensive branch
+                await queue.put(message)
+
+    def subscribe(self) -> TopicSubscription[T]:
+        """Register a new subscriber and return its queue wrapper."""
+        queue: asyncio.Queue[T] = asyncio.Queue(maxsize=self._max_queue)
+        self._subscribers.add(queue)
+        return TopicSubscription(self, queue)
+
+    def _unsubscribe(self, queue: asyncio.Queue[T]) -> None:
+        self._subscribers.discard(queue)
+
+    def __len__(self) -> int:  # pragma: no cover - debug helper
+        return len(self._subscribers)

--- a/services/execution/models.py
+++ b/services/execution/models.py
@@ -1,0 +1,99 @@
+"""Core dataclasses used across the execution service."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+@dataclass(slots=True)
+class SecretRef:
+    """Reference to a secret stored in Vault, Kubernetes, or the environment."""
+
+    source: str = "env"
+    name: str = ""
+    key: Optional[str] = None
+
+    @classmethod
+    def from_value(
+        cls,
+        value: Any,
+        *,
+        default_source: str = "env",
+    ) -> Optional["SecretRef"]:
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, Mapping):
+            src = str(value.get("source", default_source or "env")).lower()
+            name = value.get("name") or value.get("path") or value.get("value")
+            if not name:
+                return None
+            return cls(source=src, name=str(name), key=value.get("key"))
+        if isinstance(value, str):
+            if default_source == "literal":
+                return cls(source="literal", name=value)
+            return cls(source=default_source or "env", name=value)
+        return cls(source="literal", name=str(value))
+
+
+@dataclass(slots=True)
+class ExchangeCredentials:
+    """Resolved exchange credentials."""
+
+    api_key: str
+    api_secret: str
+    passphrase: Optional[str] = None
+    ws_token: Optional[str] = None
+    api_token: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ExchangeSession:
+    """Represents an active exchange session managed by the service."""
+
+    exchange: Any
+    ws_client: Optional[Any]
+    config_hash: str
+
+
+@dataclass(slots=True)
+class OrderRequest:
+    """Order submission payload accepted by the execution service."""
+
+    symbol: str
+    side: str
+    amount: float
+    client_order_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    dry_run: bool = True
+    use_websocket: bool = False
+    score: float = 0.0
+    config: Mapping[str, Any] = field(default_factory=dict)
+    notifier: Optional[Any] = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OrderAck:
+    """Acknowledgement message published after accepting an order."""
+
+    client_order_id: str
+    accepted: bool
+    reason: Optional[str] = None
+    timestamp: float = field(default_factory=time.time)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OrderFill:
+    """Fill event published when the exchange returns a result."""
+
+    client_order_id: str
+    success: bool
+    order: Optional[Mapping[str, Any]] = None
+    error: Optional[str] = None
+    timestamp: float = field(default_factory=time.time)
+    metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/services/execution/nonce.py
+++ b/services/execution/nonce.py
@@ -1,0 +1,29 @@
+"""Utilities for producing monotonically increasing API nonces."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from threading import Lock
+
+
+class NonceManager:
+    """Generate strictly increasing millisecond precision nonces."""
+
+    def __init__(self, buffer_ms: int = 150) -> None:
+        self._buffer_ms = max(0, int(buffer_ms))
+        self._lock = Lock()
+        self._last_nonce = 0
+
+    def next_nonce(self) -> int:
+        """Return the next nonce, ensuring strict monotonicity."""
+        with self._lock:
+            candidate = int(time.time() * 1000) + self._buffer_ms
+            if candidate <= self._last_nonce:
+                candidate = self._last_nonce + 1
+            self._last_nonce = candidate
+            return candidate
+
+    async def next_nonce_async(self) -> int:
+        """Async helper delegating to :meth:`next_nonce`."""
+        return await asyncio.to_thread(self.next_nonce)

--- a/services/execution/secrets.py
+++ b/services/execution/secrets.py
@@ -1,0 +1,118 @@
+"""Helpers for securely loading secrets used by the execution service."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from .config import CredentialsConfig
+from .models import ExchangeCredentials, SecretRef
+
+try:  # pragma: no cover - optional dependency
+    import hvac  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    hvac = None
+
+
+class SecretNotFoundError(RuntimeError):
+    """Raised when a requested secret cannot be resolved."""
+
+
+class SecretLoader:
+    """Resolve secret references backed by Vault or Kubernetes."""
+
+    def __init__(
+        self,
+        *,
+        kubernetes_base: str | Path | None = None,
+        vault_addr: Optional[str] = None,
+        vault_token: Optional[str] = None,
+    ) -> None:
+        self._k8s_base = Path(kubernetes_base or "/var/run/secrets")
+        self._vault_client = None
+        if hvac and vault_addr and vault_token:
+            client = hvac.Client(url=vault_addr, token=vault_token)
+            if client.is_authenticated():  # pragma: no branch - hvac handles auth
+                self._vault_client = client
+
+    def load_secret(self, ref: SecretRef | None) -> Optional[str]:
+        """Resolve ``ref`` returning the secret value or ``None``."""
+        if ref is None:
+            return None
+        source = (ref.source or "env").lower()
+        if source == "literal":
+            return ref.name
+        if source == "env":
+            value = os.getenv(ref.name)
+            if value is None:
+                raise SecretNotFoundError(f"Environment variable {ref.name!r} not set")
+            return value
+        if source in {"file", "kubernetes"}:
+            base = self._k8s_base if source == "kubernetes" else Path("/")
+            path = Path(ref.name)
+            if not path.is_absolute():
+                path = base / path
+            if ref.key:
+                path = path / ref.key
+            try:
+                return path.read_text().strip()
+            except FileNotFoundError as exc:  # pragma: no cover - filesystem specific
+                raise SecretNotFoundError(str(exc)) from exc
+        if source == "vault":
+            if not self._vault_client:
+                raise SecretNotFoundError("Vault client not configured or hvac unavailable")
+            if not ref.key:
+                raise SecretNotFoundError("Vault references require a key")
+            secret = self._vault_client.secrets.kv.v2.read_secret_version(path=ref.name)
+            data = secret.get("data", {}).get("data", {})
+            if ref.key not in data:
+                raise SecretNotFoundError(
+                    f"Vault secret {ref.name!r} missing key {ref.key!r}"
+                )
+            return str(data[ref.key])
+        raise SecretNotFoundError(f"Unknown secret source: {ref.source!r}")
+
+    def load_credentials(self, cfg: CredentialsConfig | None) -> Optional[ExchangeCredentials]:
+        """Load exchange credentials as configured."""
+        if cfg is None:
+            return None
+        api_key = self.load_secret(cfg.api_key)
+        api_secret = self.load_secret(cfg.api_secret)
+        passphrase = self.load_secret(cfg.passphrase)
+        ws_token = self.load_secret(cfg.ws_token)
+        api_token = self.load_secret(cfg.api_token)
+        return ExchangeCredentials(
+            api_key=api_key or "",
+            api_secret=api_secret or "",
+            passphrase=passphrase,
+            ws_token=ws_token,
+            api_token=api_token,
+        )
+
+    def to_env_mapping(self, creds: ExchangeCredentials | None) -> dict[str, str]:
+        """Return environment overrides for ``ccxt`` exchange creation."""
+        if creds is None:
+            return {}
+        env: dict[str, str] = {
+            "API_KEY": creds.api_key,
+            "API_SECRET": creds.api_secret,
+        }
+        if creds.passphrase:
+            env["API_PASSPHRASE"] = creds.passphrase
+        if creds.ws_token:
+            env["KRAKEN_WS_TOKEN"] = creds.ws_token
+        if creds.api_token:
+            env["KRAKEN_API_TOKEN"] = creds.api_token
+        return env
+
+    @staticmethod
+    def from_json(path: str | Path) -> "SecretLoader":
+        """Create loader configured via a JSON manifest (utility for tests)."""
+        data = json.loads(Path(path).read_text())
+        return SecretLoader(
+            kubernetes_base=data.get("kubernetes_base"),
+            vault_addr=data.get("vault", {}).get("addr"),
+            vault_token=data.get("vault", {}).get("token"),
+        )

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -1,0 +1,221 @@
+"""Implementation of the execution microservice."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from threading import Lock
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from crypto_bot.execution.cex_executor import execute_trade_async
+from crypto_bot.utils.telegram import TelegramNotifier, send_message
+
+from .config import ExecutionServiceConfig
+from .exchange import ExchangeFactory
+from .message_bus import AsyncTopic, TopicSubscription
+from .models import OrderAck, OrderFill, OrderRequest
+from .nonce import NonceManager
+from .secrets import SecretLoader
+
+logger = logging.getLogger("services.execution")
+
+
+class ExecutionService:
+    """Coordinates exchange connectivity and order lifecycle events."""
+
+    def __init__(
+        self,
+        config: ExecutionServiceConfig | Mapping[str, Any] | None,
+        *,
+        secret_loader: Optional[SecretLoader] = None,
+    ) -> None:
+        self._config = ExecutionServiceConfig.from_mapping(config)
+        self._secret_loader = secret_loader or SecretLoader()
+        self._nonce_manager = NonceManager()
+        self._exchange_factory = ExchangeFactory(self._secret_loader)
+        self._session_lock = Lock()
+        self._session = None
+        self._orders: MutableMapping[str, OrderRequest] = {}
+        self._results: MutableMapping[str, OrderFill] = {}
+        self._order_lock = asyncio.Lock()
+        self._ack_topic = AsyncTopic[OrderAck]()
+        self._fill_topic = AsyncTopic[OrderFill]()
+        self._telegram_notifier: Optional[TelegramNotifier] = None
+        self._init_notifier()
+
+    # ------------------------------------------------------------------
+    # Connection handling
+    # ------------------------------------------------------------------
+
+    def _init_notifier(self) -> None:
+        if not self._config.telegram.enabled:
+            return
+        token = self._secret_loader.load_secret(self._config.telegram.token)
+        chat_id = self._secret_loader.load_secret(self._config.telegram.chat_id)
+        if token and chat_id:
+            try:
+                self._telegram_notifier = TelegramNotifier(token, chat_id)
+            except Exception as exc:  # pragma: no cover - depends on telegram pkg
+                logger.warning("Failed to create Telegram notifier: %s", exc)
+
+    def ensure_session(self):
+        """Ensure an exchange session is available and return it."""
+        with self._session_lock:
+            if self._session is None:
+                credentials = self._secret_loader.load_credentials(self._config.credentials)
+                self._session = self._exchange_factory.create_session(
+                    self._config.exchange,
+                    credentials,
+                    self._nonce_manager,
+                )
+        return self._session
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def subscribe_acks(self) -> TopicSubscription[OrderAck]:
+        return self._ack_topic.subscribe()
+
+    def subscribe_fills(self) -> TopicSubscription[OrderFill]:
+        return self._fill_topic.subscribe()
+
+    def generate_client_order_id(self, prefix: str | None = None) -> str:
+        base = prefix or self._config.exchange.get("client_prefix") or "exec"
+        return f"{base}-{uuid.uuid4().hex}"
+
+    async def submit_order(self, request: OrderRequest) -> str:
+        session = self.ensure_session()
+        metadata = {
+            "symbol": request.symbol,
+            "side": request.side,
+            "amount": request.amount,
+            "dry_run": request.dry_run,
+        }
+        async with self._order_lock:
+            if request.client_order_id in self._results:
+                ack = OrderAck(
+                    client_order_id=request.client_order_id,
+                    accepted=True,
+                    reason="duplicate",
+                    metadata=metadata,
+                )
+                await self._ack_topic.publish(ack)
+                await self._fill_topic.publish(self._results[request.client_order_id])
+                return request.client_order_id
+            if request.client_order_id in self._orders:
+                return request.client_order_id
+            self._orders[request.client_order_id] = request
+        ack = OrderAck(client_order_id=request.client_order_id, accepted=True, metadata=metadata)
+        await self._ack_topic.publish(ack)
+        await self._post_ack_callbacks(ack)
+        asyncio.create_task(self._execute_order(session, request))
+        return request.client_order_id
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _execute_order(self, session, request: OrderRequest) -> None:
+        notifier = request.notifier or self._telegram_notifier
+        merged_config: Dict[str, Any] = dict(self._config.exchange)
+        merged_config.update(dict(request.config))
+        try:
+            order = await execute_trade_async(
+                session.exchange,
+                session.ws_client,
+                request.symbol,
+                request.side,
+                request.amount,
+                notifier=notifier,
+                dry_run=request.dry_run if request.dry_run is not None else self._config.dry_run,
+                use_websocket=request.use_websocket or self._config.use_websocket,
+                config=merged_config,
+                score=request.score,
+            )
+            fill = OrderFill(
+                client_order_id=request.client_order_id,
+                success=True,
+                order=order,
+                metadata={
+                    "symbol": request.symbol,
+                    "side": request.side,
+                    "amount": request.amount,
+                    "dry_run": request.dry_run,
+                },
+            )
+        except Exception as exc:  # pragma: no cover - network side effects
+            logger.exception("Order execution failed: %s", exc)
+            fill = OrderFill(
+                client_order_id=request.client_order_id,
+                success=False,
+                error=str(exc),
+                metadata={
+                    "symbol": request.symbol,
+                    "side": request.side,
+                    "amount": request.amount,
+                    "dry_run": request.dry_run,
+                },
+            )
+        async with self._order_lock:
+            self._orders.pop(request.client_order_id, None)
+            self._results[request.client_order_id] = fill
+            self._cleanup_results()
+        await self._fill_topic.publish(fill)
+        await self._post_fill_callbacks(fill)
+
+    async def _post_ack_callbacks(self, ack: OrderAck) -> None:
+        if not self._config.telegram.enabled:
+            return
+        if self._telegram_notifier is not None:
+            message = (
+                f"\u2705 Order accepted {ack.metadata.get('side')} {ack.metadata.get('amount')}"
+                f" {ack.metadata.get('symbol')} (id {ack.client_order_id})"
+            )
+            try:
+                err = self._telegram_notifier.notify(message)
+                if err:
+                    logger.warning("Telegram notification error: %s", err)
+            except Exception as exc:  # pragma: no cover - telegram optional
+                logger.warning("Failed to send Telegram acknowledgement: %s", exc)
+        else:
+            token = self._secret_loader.load_secret(self._config.telegram.token)
+            chat_id = self._secret_loader.load_secret(self._config.telegram.chat_id)
+            if token and chat_id:
+                message = (
+                    f"\u2705 Order accepted {ack.metadata.get('side')} {ack.metadata.get('amount')}"
+                    f" {ack.metadata.get('symbol')} (id {ack.client_order_id})"
+                )
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, send_message, token, chat_id, message)
+
+    async def _post_fill_callbacks(self, fill: OrderFill) -> None:
+        if not self._config.monitoring.enabled:
+            return
+        status = "filled" if fill.success else "failed"
+        logger.info(
+            "order.%s symbol=%s side=%s amount=%s id=%s",  # monitoring log line
+            status,
+            fill.metadata.get("symbol"),
+            fill.metadata.get("side"),
+            fill.metadata.get("amount"),
+            fill.client_order_id,
+        )
+
+    def _cleanup_results(self) -> None:
+        ttl = max(0.0, self._config.idempotency_ttl)
+        if not ttl:
+            return
+        threshold = time.time() - ttl
+        stale = [oid for oid, fill in self._results.items() if fill.timestamp < threshold]
+        for oid in stale:
+            self._results.pop(oid, None)
+
+    # Compatibility helpers -------------------------------------------------
+
+    def create_exchange(self):
+        """Return the underlying exchange and WebSocket client."""
+        session = self.ensure_session()
+        return session.exchange, session.ws_client


### PR DESCRIPTION
## Summary
- add a dedicated `services/execution` package that manages exchange connectivity, nonce generation, secure credential loading, and order lifecycle messaging
- integrate Telegram and monitoring hooks so acknowledgements and fills trigger notifications and metrics logging
- update the crypto bot execution adapter to submit orders through the service and await acknowledgement/fill topics before returning

## Testing
- pytest tests/test_nonce_fix.py

------
https://chatgpt.com/codex/tasks/task_e_68ca12674474833095e3184e78638d72