### PR TITLE
Add Solana token discovery service and Redis feed integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -147,6 +147,15 @@ solana_scanner:
   min_volume_usd: 1000
   min_score_threshold: 0.1
   min_liquidity_score: 0.2
+token_discovery_feed:
+  enabled: true
+  redis_host: localhost
+  redis_port: 6379
+  redis_db: 0
+  redis_channel_tokens: trading_engine.token_candidates
+  redis_channel_opportunities: trading_engine.token_opportunities
+  kafka_enabled: false
+  kafka_bootstrap_servers: localhost:9092
 symbol_batch_size: 100  # Increased for comprehensive symbol processing
 symbol_validation:
   allowed_quotes:

--- a/crypto_bot/phase_runner.py
+++ b/crypto_bot/phase_runner.py
@@ -48,6 +48,10 @@ class BotContext:
     memory_manager: Optional[object] = None
     managed_caches: Dict[str, object] = field(default_factory=dict)
 
+    # Solana discovery integration
+    solana_feed: Optional[object] = None
+    latest_solana_opportunities: List[Dict[str, Any]] = field(default_factory=list)
+
     def __post_init__(self):
         """Initialize production position sync manager and memory manager if available."""
         # Initialize position sync manager

--- a/crypto_bot/services/adapters/token_discovery.py
+++ b/crypto_bot/services/adapters/token_discovery.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+import os
+from typing import Optional
+
+import aiohttp
+
 from crypto_bot.services.interfaces import (
     TokenDiscoveryRequest,
     TokenDiscoveryResponse,
@@ -9,12 +15,39 @@ from crypto_bot.services.interfaces import (
 )
 from crypto_bot.solana.scanner import get_solana_new_tokens
 
+logger = logging.getLogger(__name__)
+
 
 class TokenDiscoveryAdapter(TokenDiscoveryService):
-    """Adapter for :mod:`crypto_bot.solana.scanner`."""
+    """Adapter for ``crypto_bot.solana.scanner`` with optional HTTP delegation."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self._base_url = base_url or os.getenv("TOKEN_DISCOVERY_SERVICE_URL")
 
     async def discover_tokens(
         self, request: TokenDiscoveryRequest
     ) -> TokenDiscoveryResponse:
-        tokens = await get_solana_new_tokens(dict(request.config))
-        return TokenDiscoveryResponse(tokens=list(tokens or []))
+        tokens: list[str] | None = None
+        if self._base_url:
+            url = self._base_url.rstrip("/") + "/scan/basic"
+            payload = {
+                "limit": int(dict(request.config).get("max_tokens_per_scan", 0) or 20)
+            }
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, json=payload, timeout=20) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            tokens = list(data.get("tokens", []) or [])
+                        else:
+                            text = await resp.text()
+                            logger.warning(
+                                "Token discovery service returned %s: %s", resp.status, text
+                            )
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.warning("Token discovery service request failed: %s", exc)
+
+        if tokens is None:
+            raw_tokens = await get_solana_new_tokens(dict(request.config))
+            tokens = list(raw_tokens or [])
+        return TokenDiscoveryResponse(tokens=tokens)

--- a/crypto_bot/solana/discovery_feed.py
+++ b/crypto_bot/solana/discovery_feed.py
@@ -1,0 +1,311 @@
+"""Client-side utilities for consuming token discovery events."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Dict, List, Optional, Sequence
+
+import redis.asyncio as redis
+
+try:  # pragma: no cover - optional dependency
+    from aiokafka import AIOKafkaConsumer
+except Exception:  # pragma: no cover - aiokafka optional
+    AIOKafkaConsumer = None  # type: ignore[misc,assignment]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FeedSettings:
+    """Configuration for the discovery feed consumer."""
+
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    redis_db: int = 0
+    redis_use_ssl: bool = False
+    redis_channel_tokens: str = "trading_engine.token_candidates"
+    redis_channel_opportunities: str = "trading_engine.token_opportunities"
+
+    kafka_enabled: bool = False
+    kafka_bootstrap_servers: str = "localhost:9092"
+    kafka_group_id: str = "token-discovery-consumer"
+    kafka_topic_tokens: str = "token-discovery.tokens"
+    kafka_topic_opportunities: str = "token-discovery.opportunities"
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FeedSettings":
+        params = dict(data)
+        return cls(
+            redis_host=str(params.get("redis_host", cls.redis_host)),
+            redis_port=int(params.get("redis_port", cls.redis_port)),
+            redis_db=int(params.get("redis_db", cls.redis_db)),
+            redis_use_ssl=bool(params.get("redis_use_ssl", cls.redis_use_ssl)),
+            redis_channel_tokens=str(
+                params.get("redis_channel_tokens", cls.redis_channel_tokens)
+            ),
+            redis_channel_opportunities=str(
+                params.get(
+                    "redis_channel_opportunities",
+                    cls.redis_channel_opportunities,
+                )
+            ),
+            kafka_enabled=bool(params.get("kafka_enabled", cls.kafka_enabled)),
+            kafka_bootstrap_servers=str(
+                params.get("kafka_bootstrap_servers", cls.kafka_bootstrap_servers)
+            ),
+            kafka_group_id=str(params.get("kafka_group_id", cls.kafka_group_id)),
+            kafka_topic_tokens=str(
+                params.get("kafka_topic_tokens", cls.kafka_topic_tokens)
+            ),
+            kafka_topic_opportunities=str(
+                params.get(
+                    "kafka_topic_opportunities", cls.kafka_topic_opportunities
+                )
+            ),
+        )
+
+    def redis_dsn(self) -> str:
+        protocol = "rediss" if self.redis_use_ssl else "redis"
+        return f"{protocol}://{self.redis_host}:{self.redis_port}/{self.redis_db}"
+
+
+class SolanaDiscoveryFeed:
+    """Asynchronous consumer for token discovery events."""
+
+    def __init__(self, settings: FeedSettings) -> None:
+        self._settings = settings
+        self._redis: Optional[redis.Redis] = None
+        self._redis_task: Optional[asyncio.Task] = None
+        self._redis_pubsub: Optional[redis.client.PubSub] = None
+
+        self._kafka_consumer: Optional[AIOKafkaConsumer] = None
+        self._kafka_task: Optional[asyncio.Task] = None
+
+        self._pending_tokens: Deque[str] = deque()
+        self._recent_batches: Deque[List[str]] = deque(maxlen=5)
+        self._opportunity_map: Dict[str, Dict[str, Any]] = {}
+
+        self._lock = asyncio.Lock()
+        self._closed = asyncio.Event()
+
+    async def start(self) -> None:
+        """Connect to messaging backends and start listeners."""
+
+        if self._redis is None:
+            self._redis = redis.from_url(
+                self._settings.redis_dsn(),
+                encoding="utf-8",
+                decode_responses=True,
+                health_check_interval=30,
+            )
+            try:
+                await self._redis.ping()
+            except Exception as exc:
+                logger.warning("Unable to connect to Redis feed: %s", exc)
+                await self._redis.close()
+                self._redis = None
+            else:
+                self._redis_pubsub = self._redis.pubsub(ignore_subscribe_messages=True)
+                await self._redis_pubsub.subscribe(
+                    self._settings.redis_channel_tokens,
+                    self._settings.redis_channel_opportunities,
+                )
+                self._redis_task = asyncio.create_task(
+                    self._redis_listener(), name="solana-feed-redis"
+                )
+
+        if self._settings.kafka_enabled and AIOKafkaConsumer is not None:
+            self._kafka_consumer = AIOKafkaConsumer(
+                self._settings.kafka_topic_tokens,
+                self._settings.kafka_topic_opportunities,
+                bootstrap_servers=self._settings.kafka_bootstrap_servers,
+                group_id=self._settings.kafka_group_id,
+                enable_auto_commit=True,
+                auto_offset_reset="latest",
+            )
+            try:
+                await self._kafka_consumer.start()
+            except Exception as exc:
+                logger.warning("Unable to start Kafka consumer: %s", exc)
+                self._kafka_consumer = None
+            else:
+                self._kafka_task = asyncio.create_task(
+                    self._kafka_listener(), name="solana-feed-kafka"
+                )
+
+    async def close(self) -> None:
+        """Stop background listeners and close connections."""
+
+        self._closed.set()
+
+        if self._redis_task:
+            self._redis_task.cancel()
+            try:
+                await self._redis_task
+            except asyncio.CancelledError:
+                pass
+        self._redis_task = None
+
+        if self._redis_pubsub is not None:
+            with contextlib.suppress(Exception):
+                await self._redis_pubsub.close()
+            self._redis_pubsub = None
+
+        if self._redis is not None:
+            await self._redis.close()
+            self._redis = None
+
+        if self._kafka_task:
+            self._kafka_task.cancel()
+            try:
+                await self._kafka_task
+            except asyncio.CancelledError:
+                pass
+        self._kafka_task = None
+
+        if self._kafka_consumer is not None:
+            try:
+                await self._kafka_consumer.stop()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("Failed to stop Kafka consumer", exc_info=True)
+            self._kafka_consumer = None
+
+    async def fetch_tokens(self, limit: Optional[int] = None) -> List[str]:
+        """Return queued tokens from the discovery stream."""
+
+        async with self._lock:
+            tokens: List[str] = []
+            while self._pending_tokens and (limit is None or len(tokens) < limit):
+                tokens.append(self._pending_tokens.popleft())
+            return tokens
+
+    async def get_opportunities(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        async with self._lock:
+            items = list(self._opportunity_map.values())
+        items.sort(key=lambda item: float(item.get("score", 0.0)), reverse=True)
+        if limit is None:
+            return [dict(item) for item in items]
+        return [dict(item) for item in items[:limit]]
+
+    async def score_tokens(self, tokens: Sequence[str]) -> List[Dict[str, Any]]:
+        async with self._lock:
+            opportunity_map = dict(self._opportunity_map)
+            recent_flat: List[str] = [
+                token
+                for batch in self._recent_batches
+                for token in batch
+            ]
+
+        scored: List[Dict[str, Any]] = []
+        for index, token in enumerate(tokens):
+            opportunity = opportunity_map.get(token)
+            if opportunity:
+                metadata = {
+                    key: value
+                    for key, value in opportunity.items()
+                    if key not in {"symbol", "token", "score", "source"}
+                }
+                scored.append(
+                    {
+                        "token": token,
+                        "score": float(opportunity.get("score", 0.0)),
+                        "source": opportunity.get("source", "enhanced"),
+                        "metadata": metadata,
+                    }
+                )
+            else:
+                try:
+                    rank = recent_flat.index(token)
+                except ValueError:
+                    rank = index
+                baseline = max(0.0, 1.0 - min(rank, 100) / 100.0)
+                scored.append(
+                    {
+                        "token": token,
+                        "score": baseline,
+                        "source": "baseline",
+                        "metadata": {"rank": rank},
+                    }
+                )
+        scored.sort(key=lambda item: item["score"], reverse=True)
+        return scored
+
+    async def _redis_listener(self) -> None:
+        assert self._redis_pubsub is not None
+        try:
+            async for message in self._redis_pubsub.listen():
+                if message is None:
+                    continue
+                data = message.get("data")
+                if data is None:
+                    continue
+                await self._handle_payload(data)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Redis discovery listener failed")
+        finally:
+            if self._redis_pubsub is not None:
+                with contextlib.suppress(Exception):
+                    await self._redis_pubsub.close()
+                self._redis_pubsub = None
+
+    async def _kafka_listener(self) -> None:
+        assert self._kafka_consumer is not None
+        try:
+            async for msg in self._kafka_consumer:
+                await self._handle_payload(msg.value.decode("utf-8"))
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Kafka discovery listener failed")
+
+    async def _handle_payload(self, payload: Any) -> None:
+        try:
+            if isinstance(payload, (bytes, bytearray)):
+                payload = payload.decode("utf-8")
+            if isinstance(payload, str):
+                data = json.loads(payload)
+            elif isinstance(payload, dict):
+                data = payload
+            else:
+                return
+        except (json.JSONDecodeError, TypeError):
+            logger.debug("Ignoring malformed discovery payload: %r", payload)
+            return
+
+        payload_type = data.get("type")
+        if payload_type == "tokens":
+            tokens = [str(token) for token in data.get("tokens", []) if token]
+            if not tokens:
+                return
+            async with self._lock:
+                for token in tokens:
+                    self._pending_tokens.append(token)
+                self._recent_batches.append(tokens)
+        elif payload_type == "opportunities":
+            opportunities = data.get("opportunities", [])
+            if not isinstance(opportunities, list):
+                return
+            async with self._lock:
+                for opportunity in opportunities:
+                    if not isinstance(opportunity, dict):
+                        continue
+                    symbol = str(
+                        opportunity.get("symbol")
+                        or opportunity.get("token")
+                        or ""
+                    )
+                    if not symbol:
+                        continue
+                    normalized = dict(opportunity)
+                    normalized.setdefault("source", data.get("source", "enhanced"))
+                    self._opportunity_map[symbol] = normalized
+
+
+__all__ = ["FeedSettings", "SolanaDiscoveryFeed"]

--- a/services/token_discovery/Dockerfile
+++ b/services/token_discovery/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY services/token_discovery/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY services /app/services
+COPY crypto_bot /app/crypto_bot
+
+WORKDIR /app/services/token_discovery
+ENV PYTHONPATH=/app
+
+EXPOSE 8005
+
+CMD ["uvicorn", "services.token_discovery.app:app", "--host", "0.0.0.0", "--port", "8005"]

--- a/services/token_discovery/__init__.py
+++ b/services/token_discovery/__init__.py
@@ -1,0 +1,5 @@
+"""Token discovery microservice."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/token_discovery/app.py
+++ b/services/token_discovery/app.py
@@ -1,0 +1,185 @@
+"""FastAPI application exposing token discovery endpoints."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+import redis.asyncio as redis
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+
+from .config import Settings, get_settings
+from .publisher import DiscoveryPublisher
+from .scanner import TokenDiscoveryCoordinator
+from .schemas import (
+    DiscoveryResponse,
+    Opportunity,
+    OpportunityResponse,
+    ScanRequest,
+    ScoreRequest,
+    ScoreResponse,
+    StatusResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+def lifespan(app: FastAPI):
+    settings = get_settings()
+    logging.getLogger().setLevel(settings.log_level.upper())
+
+    redis_client = redis.from_url(
+        settings.redis_dsn(),
+        encoding="utf-8",
+        decode_responses=True,
+        health_check_interval=30,
+    )
+    try:
+        await redis_client.ping()
+    except Exception as exc:  # pragma: no cover - startup failure is fatal
+        logger.error("Unable to connect to Redis: %s", exc)
+        await redis_client.close()
+        raise
+
+    publisher = DiscoveryPublisher(redis_client, settings)
+    coordinator = TokenDiscoveryCoordinator(settings, publisher)
+    await coordinator.start()
+
+    app.state.settings = settings
+    app.state.redis = redis_client
+    app.state.publisher = publisher
+    app.state.coordinator = coordinator
+
+    try:
+        yield
+    finally:
+        await coordinator.shutdown()
+        await publisher.close()
+        await redis_client.close()
+
+
+def get_settings_dependency(request: Request) -> Settings:
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    if settings is None:
+        settings = get_settings()
+    return settings
+
+
+def get_coordinator(request: Request) -> TokenDiscoveryCoordinator:
+    coordinator: TokenDiscoveryCoordinator | None = getattr(
+        request.app.state, "coordinator", None
+    )
+    if coordinator is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+    return coordinator
+
+
+def get_redis_client(request: Request) -> redis.Redis:
+    redis_client: redis.Redis | None = getattr(request.app.state, "redis", None)
+    if redis_client is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+    return redis_client
+
+
+def _opportunity_from_dict(data: dict[str, Any]) -> Opportunity:
+    return Opportunity(
+        token=str(data.get("symbol") or data.get("token")),
+        score=float(data.get("score", 0.0)),
+        source=str(data.get("source", "enhanced")),
+        metadata={
+            key: value
+            for key, value in data.items()
+            if key not in {"symbol", "token", "score", "source"}
+        },
+    )
+
+
+app = FastAPI(title="Token Discovery Service", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/status", response_model=StatusResponse)
+async def status_endpoint(
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+    settings: Settings = Depends(get_settings_dependency),
+    redis_client: redis.Redis = Depends(get_redis_client),
+) -> StatusResponse:
+    try:
+        await redis_client.ping()
+        redis_ok = True
+    except Exception:  # pragma: no cover - defensive fallback
+        redis_ok = False
+
+    kafka_ok = bool(settings.kafka_enabled)
+    stats = coordinator.get_status()
+    return StatusResponse(
+        status="ok",
+        redis_connected=redis_ok,
+        kafka_connected=kafka_ok,
+        last_basic_scan=stats.get("last_basic_scan"),
+        last_enhanced_scan=stats.get("last_enhanced_scan"),
+        tokens_cached=stats.get("tokens_cached", 0),
+        opportunities_cached=stats.get("opportunities_cached", 0),
+    )
+
+
+@app.post("/scan/basic", response_model=DiscoveryResponse)
+async def trigger_basic_scan(
+    request: ScanRequest,
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+) -> DiscoveryResponse:
+    tokens = await coordinator.run_basic_scan(limit=request.limit)
+    return DiscoveryResponse(
+        tokens=tokens,
+        metadata={"source": request.source or "basic", "count": len(tokens)},
+    )
+
+
+@app.post("/scan/enhanced", response_model=OpportunityResponse)
+async def trigger_enhanced_scan(
+    request: ScanRequest,
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+) -> OpportunityResponse:
+    opportunities = await coordinator.run_enhanced_scan(limit=request.limit)
+    payload = [_opportunity_from_dict(item) for item in opportunities]
+    return OpportunityResponse(
+        opportunities=payload,
+        metadata={"source": request.source or "enhanced", "count": len(payload)},
+    )
+
+
+@app.get("/tokens/latest", response_model=DiscoveryResponse)
+async def latest_tokens(
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+) -> DiscoveryResponse:
+    tokens = await coordinator.get_latest_tokens()
+    return DiscoveryResponse(tokens=tokens, metadata={"count": len(tokens)})
+
+
+@app.get("/opportunities/top", response_model=OpportunityResponse)
+async def top_opportunities(
+    limit: int = 10,
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+) -> OpportunityResponse:
+    opportunities = await coordinator.get_latest_opportunities(limit=limit)
+    payload = [_opportunity_from_dict(item) for item in opportunities]
+    return OpportunityResponse(opportunities=payload, metadata={"count": len(payload)})
+
+
+@app.post("/opportunities/score", response_model=ScoreResponse)
+async def score_tokens(
+    request: ScoreRequest,
+    coordinator: TokenDiscoveryCoordinator = Depends(get_coordinator),
+) -> ScoreResponse:
+    opportunities = await coordinator.score_tokens(request.tokens)
+    payload = [_opportunity_from_dict(item) for item in opportunities]
+    return ScoreResponse(opportunities=payload, metadata={"count": len(payload)})
+
+
+__all__ = ["app"]

--- a/services/token_discovery/config.py
+++ b/services/token_discovery/config.py
@@ -1,0 +1,86 @@
+"""Configuration for the token discovery microservice."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the token discovery service."""
+
+    app_name: str = Field(default="Token Discovery Service")
+    log_level: str = Field(default="INFO")
+
+    # Redis configuration
+    redis_host: str = Field(default="localhost")
+    redis_port: int = Field(default=6379)
+    redis_db: int = Field(default=0)
+    redis_use_ssl: bool = Field(default=False)
+    redis_channel_tokens: str = Field(
+        default="trading_engine.token_candidates",
+        description="Channel for publishing discovered token batches.",
+    )
+    redis_channel_opportunities: str = Field(
+        default="trading_engine.token_opportunities",
+        description="Channel for publishing scored opportunity payloads.",
+    )
+
+    # Kafka configuration
+    kafka_enabled: bool = Field(default=False)
+    kafka_bootstrap_servers: str = Field(default="localhost:9092")
+    kafka_topic_tokens: str = Field(default="token-discovery.tokens")
+    kafka_topic_opportunities: str = Field(
+        default="token-discovery.opportunities"
+    )
+    kafka_client_id: str = Field(default="token-discovery-service")
+
+    # Background scanning configuration
+    background_basic_interval: int = Field(
+        default=300, description="Interval between basic scans in seconds."
+    )
+    background_enhanced_interval: int = Field(
+        default=900,
+        description="Interval between enhanced scans/opportunity publication in seconds.",
+    )
+    publish_batch_size: int = Field(
+        default=50, description="Maximum number of items to publish per batch."
+    )
+
+    # Solana scanner configuration
+    solana_scanner_limit: int = Field(default=20)
+    solana_min_volume_usd: float = Field(default=0.0)
+    solana_gecko_search: bool = Field(default=True)
+    helius_key: str = Field(default="")
+    raydium_api_key: str = Field(default="")
+    pump_fun_api_key: str = Field(default="")
+
+    # Enhanced scanner configuration
+    enable_enhanced_scanner: bool = Field(default=True)
+    enhanced_min_score: float = Field(default=0.25)
+    enhanced_limit: int = Field(default=20)
+
+    model_config = SettingsConfigDict(
+        env_prefix="TOKEN_DISCOVERY_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    def redis_dsn(self) -> str:
+        """Return the configured Redis DSN."""
+
+        protocol = "rediss" if self.redis_use_ssl else "redis"
+        return f"{protocol}://{self.redis_host}:{self.redis_port}/{self.redis_db}"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached :class:`Settings` instance."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/services/token_discovery/main.py
+++ b/services/token_discovery/main.py
@@ -1,0 +1,22 @@
+"""Entrypoint for running the token discovery service with uvicorn."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from .config import get_settings
+
+
+def main() -> None:
+    settings = get_settings()
+    uvicorn.run(
+        "services.token_discovery.app:app",
+        host="0.0.0.0",
+        port=8005,
+        reload=False,
+        log_level=settings.log_level.lower(),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/services/token_discovery/publisher.py
+++ b/services/token_discovery/publisher.py
@@ -1,0 +1,138 @@
+"""Utilities for publishing discovery results to Redis and Kafka."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Mapping, MutableMapping, Optional, Sequence
+
+import redis.asyncio as redis
+
+try:  # pragma: no cover - optional dependency
+    from aiokafka import AIOKafkaProducer
+except Exception:  # pragma: no cover - aiokafka optional
+    AIOKafkaProducer = None  # type: ignore[misc,assignment]
+
+from .config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class DiscoveryPublisher:
+    """Publish discovery results to downstream messaging backends."""
+
+    def __init__(self, redis_client: redis.Redis, settings: Settings) -> None:
+        self._redis = redis_client
+        self._settings = settings
+        self._kafka_producer: Optional[AIOKafkaProducer] = None
+        self._kafka_lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        """Clean up resources held by the publisher."""
+
+        if self._kafka_producer is not None:
+            try:
+                await self._kafka_producer.stop()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("Failed to stop Kafka producer", exc_info=True)
+            self._kafka_producer = None
+
+    async def publish_tokens(
+        self,
+        tokens: Sequence[str],
+        *,
+        source: str,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        """Publish discovered tokens to Redis and Kafka."""
+
+        if not tokens:
+            return
+
+        payload = {
+            "type": "tokens",
+            "source": source,
+            "tokens": list(tokens),
+            "metadata": dict(metadata or {}),
+            "published_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        message = json.dumps(payload)
+        await self._publish_to_redis(message, self._settings.redis_channel_tokens)
+        await self._publish_to_kafka(message, self._settings.kafka_topic_tokens)
+
+    async def publish_opportunities(
+        self,
+        opportunities: Sequence[MutableMapping[str, object] | Mapping[str, object]],
+        *,
+        source: str,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        """Publish scored opportunities to Redis and Kafka."""
+
+        if not opportunities:
+            return
+
+        serialisable: list[dict[str, object]] = []
+        for item in opportunities:
+            serialisable.append(dict(item))
+
+        payload = {
+            "type": "opportunities",
+            "source": source,
+            "opportunities": serialisable,
+            "metadata": dict(metadata or {}),
+            "published_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        message = json.dumps(payload)
+        await self._publish_to_redis(message, self._settings.redis_channel_opportunities)
+        await self._publish_to_kafka(message, self._settings.kafka_topic_opportunities)
+
+    async def _publish_to_redis(self, message: str, channel: str) -> None:
+        try:
+            await self._redis.publish(channel, message)
+            logger.debug("Published message to Redis channel %s", channel)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to publish to Redis channel %s: %s", channel, exc)
+
+    async def _publish_to_kafka(self, message: str, topic: str) -> None:
+        if not self._settings.kafka_enabled:
+            return
+        if AIOKafkaProducer is None:
+            logger.warning("Kafka publishing requested but aiokafka is not installed")
+            return
+
+        producer = await self._ensure_kafka_producer()
+        if producer is None:
+            return
+        try:
+            await producer.send_and_wait(topic, message.encode("utf-8"))
+            logger.debug("Published message to Kafka topic %s", topic)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to publish to Kafka topic %s: %s", topic, exc)
+
+    async def _ensure_kafka_producer(self) -> Optional[AIOKafkaProducer]:
+        if not self._settings.kafka_enabled:
+            return None
+        if AIOKafkaProducer is None:
+            return None
+        async with self._kafka_lock:
+            if self._kafka_producer is not None:
+                return self._kafka_producer
+            producer = AIOKafkaProducer(
+                bootstrap_servers=self._settings.kafka_bootstrap_servers,
+                client_id=self._settings.kafka_client_id,
+            )
+            try:
+                await producer.start()
+            except Exception as exc:  # pragma: no cover - connection errors
+                logger.warning("Unable to start Kafka producer: %s", exc)
+                return None
+            self._kafka_producer = producer
+            return producer
+
+
+__all__ = ["DiscoveryPublisher"]

--- a/services/token_discovery/requirements.txt
+++ b/services/token_discovery/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.95.0,<0.101.0
+uvicorn[standard]>=0.21.0,<0.24.0
+redis>=4.3.0,<5.0.0
+aiohttp>=3.9.0,<4.0.0
+pydantic>=2.0.0,<2.5.0
+pydantic-settings>=2.0.0,<2.1.0
+aiokafka>=0.8.1

--- a/services/token_discovery/scanner.py
+++ b/services/token_discovery/scanner.py
@@ -1,0 +1,247 @@
+"""High level orchestration for Solana token discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from crypto_bot.solana.scanner import get_solana_new_tokens
+from crypto_bot.solana.enhanced_scanner import EnhancedSolanaScanner
+
+from .config import Settings
+from .publisher import DiscoveryPublisher
+
+logger = logging.getLogger(__name__)
+
+
+class TokenDiscoveryCoordinator:
+    """Coordinate Solana token discovery and opportunity scoring."""
+
+    def __init__(self, settings: Settings, publisher: DiscoveryPublisher) -> None:
+        self._settings = settings
+        self._publisher = publisher
+
+        self._lock = asyncio.Lock()
+        self._basic_task: Optional[asyncio.Task] = None
+        self._enhanced_task: Optional[asyncio.Task] = None
+        self._enhanced_scanner: Optional[EnhancedSolanaScanner] = None
+
+        self._latest_tokens: list[str] = []
+        self._latest_opportunities: list[dict[str, Any]] = []
+        self._last_basic_scan: Optional[datetime] = None
+        self._last_enhanced_scan: Optional[datetime] = None
+
+    async def start(self) -> None:
+        """Start background scanning loops."""
+
+        if self._settings.background_basic_interval > 0:
+            self._basic_task = asyncio.create_task(
+                self._basic_loop(), name="token-discovery-basic"
+            )
+        if self._settings.enable_enhanced_scanner and self._settings.background_enhanced_interval > 0:
+            self._enhanced_task = asyncio.create_task(
+                self._enhanced_loop(), name="token-discovery-enhanced"
+            )
+
+    async def shutdown(self) -> None:
+        """Stop background scanning loops and cleanup resources."""
+
+        tasks = [task for task in (self._basic_task, self._enhanced_task) if task]
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Discovery loop terminated with error")
+        self._basic_task = None
+        self._enhanced_task = None
+
+    async def run_basic_scan(self, limit: Optional[int] = None) -> list[str]:
+        """Run a single basic Solana discovery scan."""
+
+        scan_limit = int(limit or self._settings.solana_scanner_limit)
+        config = self._build_basic_config(scan_limit)
+
+        tokens = await get_solana_new_tokens(config)
+        formatted = [self._format_token(token) for token in tokens]
+
+        async with self._lock:
+            self._latest_tokens = list(formatted)
+            self._last_basic_scan = datetime.now(timezone.utc)
+
+        await self._publisher.publish_tokens(
+            formatted,
+            source="basic",
+            metadata={"limit": scan_limit},
+        )
+        return formatted
+
+    async def run_enhanced_scan(self, limit: Optional[int] = None) -> list[dict[str, Any]]:
+        """Run an enhanced scan and publish opportunities."""
+
+        if not self._settings.enable_enhanced_scanner:
+            return []
+
+        scanner = await self._get_enhanced_scanner()
+        if hasattr(scanner, "_perform_scan"):
+            await scanner._perform_scan()  # type: ignore[attr-defined]
+        opportunities = scanner.get_top_opportunities(
+            limit=limit or self._settings.enhanced_limit
+        )
+
+        async with self._lock:
+            self._latest_opportunities = [dict(opp) for opp in opportunities]
+            self._last_enhanced_scan = datetime.now(timezone.utc)
+
+        await self._publisher.publish_opportunities(
+            opportunities,
+            source="enhanced",
+            metadata={"limit": limit or self._settings.enhanced_limit},
+        )
+        return [dict(opp) for opp in opportunities]
+
+    async def get_latest_tokens(self) -> list[str]:
+        async with self._lock:
+            return list(self._latest_tokens)
+
+    async def get_latest_opportunities(self, limit: Optional[int] = None) -> list[dict[str, Any]]:
+        async with self._lock:
+            if limit is None:
+                return [dict(opp) for opp in self._latest_opportunities]
+            return [dict(opp) for opp in self._latest_opportunities[:limit]]
+
+    async def score_tokens(self, tokens: Sequence[str]) -> list[dict[str, Any]]:
+        """Score arbitrary tokens using cached opportunities or heuristics."""
+
+        if not tokens:
+            return []
+
+        async with self._lock:
+            opportunity_map = {
+                opp.get("symbol") or opp.get("token"): dict(opp)
+                for opp in self._latest_opportunities
+            }
+            cached_tokens = list(self._latest_tokens)
+
+        scored: list[dict[str, Any]] = []
+        for index, token in enumerate(tokens):
+            opportunity = opportunity_map.get(token)
+            if opportunity:
+                score = float(opportunity.get("score", 0.0))
+                metadata = {
+                    key: value
+                    for key, value in opportunity.items()
+                    if key not in {"symbol", "token", "score"}
+                }
+                scored.append(
+                    {
+                        "token": token,
+                        "score": score,
+                        "source": opportunity.get("source", "enhanced"),
+                        "metadata": metadata,
+                    }
+                )
+            else:
+                baseline = self._baseline_score(token, index, cached_tokens)
+                scored.append(
+                    {
+                        "token": token,
+                        "score": baseline,
+                        "source": "baseline",
+                        "metadata": {"rank": index},
+                    }
+                )
+
+        scored.sort(key=lambda item: item["score"], reverse=True)
+        return scored
+
+    def get_status(self) -> dict[str, Any]:
+        """Return diagnostic information for service status endpoints."""
+
+        return {
+            "last_basic_scan": self._last_basic_scan,
+            "last_enhanced_scan": self._last_enhanced_scan,
+            "tokens_cached": len(self._latest_tokens),
+            "opportunities_cached": len(self._latest_opportunities),
+        }
+
+    async def _basic_loop(self) -> None:
+        interval = max(self._settings.background_basic_interval, 1)
+        while True:
+            try:
+                await self.run_basic_scan()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # pragma: no cover - loop safety
+                logger.exception("Basic discovery loop failed")
+            await asyncio.sleep(interval)
+
+    async def _enhanced_loop(self) -> None:
+        interval = max(self._settings.background_enhanced_interval, 1)
+        while True:
+            try:
+                await self.run_enhanced_scan()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # pragma: no cover - loop safety
+                logger.exception("Enhanced discovery loop failed")
+            await asyncio.sleep(interval)
+
+    async def _get_enhanced_scanner(self) -> EnhancedSolanaScanner:
+        if self._enhanced_scanner is None:
+            config = self._build_enhanced_config()
+            self._enhanced_scanner = EnhancedSolanaScanner(config)
+        return self._enhanced_scanner
+
+    def _build_basic_config(self, limit: int) -> Mapping[str, Any]:
+        return {
+            "max_tokens_per_scan": limit,
+            "min_volume_usd": self._settings.solana_min_volume_usd,
+            "gecko_search": self._settings.solana_gecko_search,
+            "helius_key": self._settings.helius_key,
+            "raydium_api_key": self._settings.raydium_api_key,
+            "pump_fun_api_key": self._settings.pump_fun_api_key,
+        }
+
+    def _build_enhanced_config(self) -> Dict[str, Any]:
+        return {
+            "solana_scanner": {
+                "max_tokens_per_scan": self._settings.solana_scanner_limit,
+                "min_volume_usd": self._settings.solana_min_volume_usd,
+                "gecko_search": self._settings.solana_gecko_search,
+                "helius_key": self._settings.helius_key,
+                "raydium_api_key": self._settings.raydium_api_key,
+                "pump_fun_api_key": self._settings.pump_fun_api_key,
+            },
+            "enhanced_scanning": {
+                "enabled": self._settings.enable_enhanced_scanner,
+                "min_score_threshold": self._settings.enhanced_min_score,
+                "max_tokens_per_scan": self._settings.enhanced_limit,
+                "min_confidence": 0.5,
+                "min_liquidity_score": 0.2,
+            },
+        }
+
+    @staticmethod
+    def _format_token(token: str) -> str:
+        if "/" in token:
+            return token
+        return f"{token}/USDC"
+
+    @staticmethod
+    def _baseline_score(token: str, index: int, cached_tokens: Sequence[str]) -> float:
+        try:
+            position = cached_tokens.index(token)
+        except ValueError:
+            position = index
+        # Provide a simple decay based on position while remaining within [0, 1]
+        rank = min(position, 100)
+        return max(0.0, 1.0 - (rank / 100.0))
+
+
+__all__ = ["TokenDiscoveryCoordinator"]

--- a/services/token_discovery/schemas.py
+++ b/services/token_discovery/schemas.py
@@ -1,0 +1,86 @@
+"""Pydantic schemas exposed by the token discovery service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Sequence
+
+from pydantic import BaseModel, Field, validator
+
+
+class ScanRequest(BaseModel):
+    """Request payload for triggering discovery scans."""
+
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=500,
+        description="Maximum number of tokens to return in the response.",
+    )
+    source: Optional[str] = Field(
+        default=None,
+        description="Optional override for the scan source identifier.",
+    )
+
+
+class DiscoveryResponse(BaseModel):
+    """Response payload for discovery endpoints."""
+
+    tokens: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Opportunity(BaseModel):
+    """Opportunity payload returned to downstream consumers."""
+
+    token: str = Field(..., description="Token mint or trading symbol.")
+    score: float = Field(..., description="Normalized opportunity score.")
+    source: str = Field(default="enhanced")
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @validator("score")
+    def _normalize_score(cls, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))
+
+
+class OpportunityResponse(BaseModel):
+    """Response payload for opportunity endpoints."""
+
+    opportunities: List[Opportunity] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ScoreRequest(BaseModel):
+    """Payload for ad-hoc opportunity scoring requests."""
+
+    tokens: Sequence[str] = Field(..., description="Tokens to score.")
+
+
+class ScoreResponse(BaseModel):
+    """Response from ad-hoc opportunity scoring."""
+
+    opportunities: List[Opportunity] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatusResponse(BaseModel):
+    """Operational status of the token discovery service."""
+
+    status: str = Field(default="ok")
+    redis_connected: bool = Field(default=True)
+    kafka_connected: bool = Field(default=False)
+    last_basic_scan: Optional[datetime] = None
+    last_enhanced_scan: Optional[datetime] = None
+    tokens_cached: int = Field(default=0)
+    opportunities_cached: int = Field(default=0)
+
+
+__all__ = [
+    "DiscoveryResponse",
+    "Opportunity",
+    "OpportunityResponse",
+    "ScanRequest",
+    "ScoreRequest",
+    "ScoreResponse",
+    "StatusResponse",
+]


### PR DESCRIPTION
## Summary
- add a FastAPI-based token discovery microservice with Solana scanning, opportunity scoring, and Redis/Kafka publishing
- introduce a Redis/Kafka discovery feed consumer for the trading bot and refactor Solana candidate handling to use it
- update configuration and adapters to route discovery through the new service-first architecture

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca1272eaac833099f36110a04c32f6