### PR TITLE
Refactor portfolio adapter to use remote service

### DIFF
--- a/crypto_bot/services/adapters/portfolio.py
+++ b/crypto_bot/services/adapters/portfolio.py
@@ -1,33 +1,251 @@
-"""In-process adapter for portfolio and trade management."""
+"""HTTP-backed portfolio adapter."""
 
 from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional, Tuple
 
 from crypto_bot.services.interfaces import (
     CreateTradeRequest,
     CreateTradeResponse,
     PortfolioService,
 )
-from crypto_bot.utils.trade_manager import create_trade, get_trade_manager
+from crypto_bot.utils.trade_manager import Trade
+from services.portfolio.clients.rest import PortfolioRestClient
+from services.portfolio.schemas import (
+    PnlBreakdown,
+    PortfolioState,
+    PositionRead,
+    RiskCheckResult,
+    TradeCreate,
+)
+
+_DEFAULT_TIMEOUT = 10.0
+TimeoutValue = float | Tuple[float, float]
+
+
+def _ensure_decimal(value: Any) -> Decimal:
+    """Convert arbitrary numeric types to :class:`Decimal`."""
+
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _env_timeout(name: str) -> Optional[float]:
+    value = os.getenv(name)
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:  # pragma: no cover - configuration error
+        raise ValueError(f"Invalid value for {name!r}: {value!r}") from exc
+
+
+def _resolve_timeout(
+    timeout: Optional[float],
+    connect_timeout: Optional[float],
+    read_timeout: Optional[float],
+) -> TimeoutValue:
+    """Determine the timeout configuration for HTTP requests."""
+
+    env_timeout = _env_timeout("PORTFOLIO_SERVICE_TIMEOUT")
+    env_connect = _env_timeout("PORTFOLIO_SERVICE_CONNECT_TIMEOUT")
+    env_read = _env_timeout("PORTFOLIO_SERVICE_READ_TIMEOUT")
+
+    connect = connect_timeout if connect_timeout is not None else env_connect
+    read = read_timeout if read_timeout is not None else env_read
+
+    if connect is not None or read is not None:
+        base = timeout if timeout is not None else env_timeout
+        default = base if base is not None else _DEFAULT_TIMEOUT
+        connect_value = connect if connect is not None else default
+        read_value = read if read is not None else default
+        return (connect_value, read_value)
+
+    if timeout is not None:
+        return timeout
+    if env_timeout is not None:
+        return env_timeout
+    return _DEFAULT_TIMEOUT
+
+
+class RemoteTradeManager:
+    """Minimal trade manager facade backed by the portfolio service."""
+
+    def __init__(self, client: PortfolioRestClient):
+        self._client = client
+        self._state: Optional[PortfolioState] = None
+        self.trades: list[Any] = []
+        self.positions: list[PositionRead] = []
+        self.closed_positions: list[PositionRead] = []
+        self.price_cache: dict[str, Decimal] = {}
+        self.total_trades: int = 0
+        self.total_volume: Decimal = Decimal("0")
+        self.total_fees: Decimal = Decimal("0")
+        self.total_realized_pnl: Decimal = Decimal("0")
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Fetch the latest state from the remote service."""
+
+        state = self._client.get_state()
+        self.update_from_state(state)
+
+    def update_from_state(self, state: PortfolioState) -> None:
+        """Apply a freshly retrieved :class:`PortfolioState`."""
+
+        self._state = state
+        self.trades = list(state.trades)
+        self.positions = list(state.positions)
+        self.closed_positions = list(state.closed_positions)
+        self.price_cache = {
+            entry.symbol: Decimal(str(entry.price)) for entry in state.price_cache
+        }
+        stats = state.statistics
+        self.total_trades = stats.total_trades
+        self.total_volume = Decimal(str(stats.total_volume))
+        self.total_fees = Decimal(str(stats.total_fees))
+        self.total_realized_pnl = Decimal(str(stats.total_realized_pnl))
+
+    def get_state(self) -> PortfolioState:
+        if self._state is None:
+            self.refresh()
+        assert self._state is not None
+        return self._state
+
+    def get_all_positions(self) -> list[PositionRead]:
+        return list(self.positions)
+
+    def get_position(self, symbol: str) -> Optional[PositionRead]:
+        for position in self.positions:
+            if position.symbol == symbol:
+                return position
+        for position in self.closed_positions:
+            if position.symbol == symbol:
+                return position
+        return None
+
+    def record_trade(self, trade: Trade) -> str:
+        payload = TradeCreate(
+            id=trade.id,
+            symbol=trade.symbol,
+            side=trade.side,
+            amount=trade.amount,
+            price=trade.price,
+            timestamp=trade.timestamp,
+            strategy=trade.strategy or None,
+            exchange=trade.exchange or None,
+            fees=trade.fees,
+            status=trade.status,
+            order_id=trade.order_id,
+            client_order_id=trade.client_order_id,
+            metadata=trade.metadata,
+        )
+        self._client.record_trade(payload)
+        self.refresh()
+        return trade.id
+
+    def update_price(self, symbol: str, price: Decimal) -> Optional[PositionRead]:
+        result = self._client.update_price(symbol, price)
+        self.refresh()
+        return result
+
+    def save_state(self) -> PortfolioState:
+        state = self.get_state()
+        self._client.put_state(state)
+        return state
 
 
 class PortfolioAdapter(PortfolioService):
-    """Adapter that exposes the TradeManager helpers via a protocol."""
+    """Adapter that proxies portfolio operations to the remote service."""
+
+    def __init__(
+        self,
+        client: Optional[PortfolioRestClient] = None,
+        *,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        connect_timeout: Optional[float] = None,
+        read_timeout: Optional[float] = None,
+    ) -> None:
+        if client is None:
+            resolved_base_url = base_url or os.getenv("PORTFOLIO_SERVICE_URL")
+            resolved_timeout = _resolve_timeout(timeout, connect_timeout, read_timeout)
+            self._client = PortfolioRestClient(
+                base_url=resolved_base_url, timeout=resolved_timeout
+            )
+        else:
+            self._client = client
+        self._trade_manager: Optional[RemoteTradeManager] = None
+
+    def _trade_manager_refresh(self) -> None:
+        if self._trade_manager is not None:
+            self._trade_manager.refresh()
 
     def create_trade(self, request: CreateTradeRequest) -> CreateTradeResponse:
-        metadata = dict(request.metadata) if request.metadata is not None else None
-        trade = create_trade(
+        metadata = dict(request.metadata) if request.metadata is not None else {}
+        trade = Trade(
+            id=str(uuid.uuid4()),
             symbol=request.symbol,
             side=request.side,
-            amount=request.amount,
-            price=request.price,
+            amount=_ensure_decimal(request.amount),
+            price=_ensure_decimal(request.price),
+            timestamp=datetime.utcnow(),
             strategy=request.strategy,
             exchange=request.exchange,
-            fees=request.fees,
+            fees=_ensure_decimal(request.fees or 0),
             order_id=request.order_id,
             client_order_id=request.client_order_id,
             metadata=metadata,
         )
+
+        payload = TradeCreate(
+            id=trade.id,
+            symbol=trade.symbol,
+            side=trade.side,
+            amount=trade.amount,
+            price=trade.price,
+            timestamp=trade.timestamp,
+            strategy=trade.strategy or None,
+            exchange=trade.exchange or None,
+            fees=trade.fees,
+            status=trade.status,
+            order_id=trade.order_id,
+            client_order_id=trade.client_order_id,
+            metadata=trade.metadata,
+        )
+        self._client.record_trade(payload)
+        self._trade_manager_refresh()
         return CreateTradeResponse(trade=trade)
 
-    def get_trade_manager(self):  # type: ignore[override]
-        return get_trade_manager()
+    def get_state(self) -> PortfolioState:
+        state = self._client.get_state()
+        if self._trade_manager is not None:
+            self._trade_manager.update_from_state(state)
+        return state
+
+    def list_positions(self) -> list[PositionRead]:
+        return self._client.list_positions()
+
+    def update_price(self, symbol: str, price: Any) -> Optional[PositionRead]:
+        decimal_price = _ensure_decimal(price)
+        result = self._client.update_price(symbol, decimal_price)
+        self._trade_manager_refresh()
+        return result
+
+    def compute_pnl(self, symbol: Optional[str] = None) -> PnlBreakdown:
+        return self._client.compute_pnl(symbol)
+
+    def check_risk(self) -> list[RiskCheckResult]:
+        return self._client.check_risk()
+
+    def get_trade_manager(self) -> RemoteTradeManager:
+        if self._trade_manager is None:
+            self._trade_manager = RemoteTradeManager(self._client)
+        else:
+            self._trade_manager.refresh()
+        return self._trade_manager

--- a/crypto_bot/services/interfaces.py
+++ b/crypto_bot/services/interfaces.py
@@ -103,8 +103,8 @@ class OrderBookResponse:
 class TimeframeRequest:
     """Request conversion of timeframe to seconds."""
 
-    exchange_id: Optional[str] = None
     timeframe: str
+    exchange_id: Optional[str] = None
 
 
 @dataclass(slots=True)
@@ -274,6 +274,21 @@ class PortfolioService(Protocol):
     """Protocol covering trade/portfolio management helpers."""
 
     def create_trade(self, request: CreateTradeRequest) -> CreateTradeResponse:
+        ...
+
+    def get_state(self) -> Any:
+        ...
+
+    def list_positions(self) -> Sequence[Any]:
+        ...
+
+    def update_price(self, symbol: str, price: Any) -> Any:
+        ...
+
+    def compute_pnl(self, symbol: Optional[str] = None) -> Any:
+        ...
+
+    def check_risk(self) -> Sequence[Any]:
         ...
 
     def get_trade_manager(self) -> Any:

--- a/tests/services/test_portfolio_adapter.py
+++ b/tests/services/test_portfolio_adapter.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import importlib.util
+import pytest
+import requests
+
+from crypto_bot.services.interfaces import CreateTradeRequest
+from services.portfolio.schemas import (
+    PnlBreakdown,
+    PortfolioState,
+    PortfolioStatistics,
+    PositionRead,
+    PriceCacheEntry,
+    RiskCheckResult,
+    TradeRead,
+)
+
+
+spec = importlib.util.spec_from_file_location(
+    "_portfolio_adapter_test_module",
+    Path(__file__).resolve().parents[2] / "crypto_bot" / "services" / "adapters" / "portfolio.py",
+)
+assert spec is not None and spec.loader is not None
+portfolio_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(portfolio_module)
+PortfolioAdapter = portfolio_module.PortfolioAdapter
+
+
+class FakePortfolioService:
+    """In-memory simulation of the portfolio-service REST API."""
+
+    def __init__(self) -> None:
+        now = datetime(2024, 1, 1, 12, 0, 0)
+        trade = TradeRead(
+            id="trade-1",
+            symbol="BTC/USDT",
+            side="buy",
+            amount=Decimal("0.5"),
+            price=Decimal("20000"),
+            timestamp=now,
+            strategy="momentum",
+            exchange="binance",
+            fees=Decimal("1"),
+            status="filled",
+            order_id="order-1",
+            client_order_id="client-1",
+            metadata={"source": "test"},
+        )
+        self.position = PositionRead(
+            symbol="BTC/USDT",
+            side="long",
+            total_amount=Decimal("0.5"),
+            average_price=Decimal("20000"),
+            realized_pnl=Decimal("0"),
+            fees_paid=Decimal("1"),
+            entry_time=now,
+            last_update=now,
+            highest_price=Decimal("20500"),
+            lowest_price=Decimal("19500"),
+            stop_loss_price=None,
+            take_profit_price=None,
+            trailing_stop_pct=None,
+            metadata={"source": "test"},
+            mark_price=Decimal("20500"),
+            is_open=True,
+            trades=[trade],
+        )
+        self.state = PortfolioState(
+            trades=[trade],
+            positions=[self.position],
+            closed_positions=[],
+            price_cache=[
+                PriceCacheEntry(symbol="BTC/USDT", price=Decimal("20500"), updated_at=now)
+            ],
+            statistics=PortfolioStatistics(
+                total_trades=1,
+                total_volume=Decimal("10000"),
+                total_fees=Decimal("1"),
+                total_realized_pnl=Decimal("100"),
+                last_updated=now,
+            ),
+        )
+        self.pnl = PnlBreakdown(
+            realized=Decimal("100"),
+            unrealized=Decimal("50"),
+            total=Decimal("150"),
+        )
+        self.risk = [
+            RiskCheckResult(name="max_position", passed=True, message="Within limits")
+        ]
+        self.trade_payloads: list[dict[str, Any]] = []
+        self.updated_prices: list[dict[str, str]] = []
+        self.pnl_requests: list[dict[str, str]] = []
+
+    def _response(self, payload: Any, status_code: int = 200) -> requests.Response:
+        response = requests.Response()
+        response.status_code = status_code
+        if payload is None:
+            response._content = b""
+        else:
+            response._content = json.dumps(payload).encode()
+            response.headers["Content-Type"] = "application/json"
+        response.url = "http://portfolio.test"
+        return response
+
+    def handle(
+        self,
+        method: str,
+        url: str,
+        timeout: Any = None,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> requests.Response:
+        path = urlparse(url).path
+        if method == "POST" and path == "/trades":
+            assert json is not None
+            self.trade_payloads.append(json)
+            return self._response(self.position.model_dump(mode="json"), status_code=201)
+        if method == "GET" and path == "/state":
+            return self._response(self.state.model_dump(mode="json"))
+        if method == "GET" and path == "/positions":
+            return self._response(
+                [pos.model_dump(mode="json") for pos in self.state.positions]
+            )
+        if method == "POST" and path == "/prices":
+            assert params is not None
+            self.updated_prices.append(params)
+            return self._response(self.position.model_dump(mode="json"))
+        if method == "GET" and path == "/pnl":
+            if params:
+                self.pnl_requests.append(params)
+            return self._response(self.pnl.model_dump(mode="json"))
+        if method == "GET" and path == "/risk":
+            return self._response([entry.model_dump(mode="json") for entry in self.risk])
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
+@pytest.fixture
+def fake_portfolio_service(monkeypatch: pytest.MonkeyPatch) -> FakePortfolioService:
+    server = FakePortfolioService()
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+        return server.handle(method, url, **kwargs)
+
+    monkeypatch.setattr(
+        "services.portfolio.clients.rest.requests.request", fake_request
+    )
+    return server
+
+
+def test_adapter_records_trades_via_rest(monkeypatch: pytest.MonkeyPatch, fake_portfolio_service: FakePortfolioService) -> None:
+    monkeypatch.setenv("PORTFOLIO_SERVICE_URL", "http://portfolio.test")
+    monkeypatch.setenv("PORTFOLIO_SERVICE_TIMEOUT", "7.5")
+    monkeypatch.setenv("PORTFOLIO_SERVICE_CONNECT_TIMEOUT", "2.0")
+    monkeypatch.setenv("PORTFOLIO_SERVICE_READ_TIMEOUT", "3.0")
+
+    adapter = PortfolioAdapter()
+    response = adapter.create_trade(
+        CreateTradeRequest(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=Decimal("0.5"),
+            price=Decimal("21000"),
+            strategy="momentum",
+            exchange="binance",
+            fees=Decimal("0.1"),
+            order_id="exchange-order",
+            client_order_id="client-order",
+            metadata={"source": "unit-test"},
+        )
+    )
+
+    assert response.trade.symbol == "BTC/USDT"
+    assert fake_portfolio_service.trade_payloads, "trade should be sent to the REST API"
+    payload = fake_portfolio_service.trade_payloads[0]
+    assert payload["symbol"] == "BTC/USDT"
+    assert Decimal(payload["amount"]) == Decimal("0.5")
+    assert adapter._client.base_url == "http://portfolio.test"
+    assert adapter._client.timeout == (2.0, 3.0)
+
+
+def test_adapter_fetches_state_and_positions(
+    monkeypatch: pytest.MonkeyPatch, fake_portfolio_service: FakePortfolioService
+) -> None:
+    monkeypatch.setenv("PORTFOLIO_SERVICE_URL", "http://portfolio.test")
+    adapter = PortfolioAdapter()
+
+    state = adapter.get_state()
+    assert state.statistics.total_trades == fake_portfolio_service.state.statistics.total_trades
+
+    positions = adapter.list_positions()
+    assert len(positions) == 1
+    assert positions[0].symbol == "BTC/USDT"
+
+
+def test_adapter_updates_prices_and_queries_pnl(
+    monkeypatch: pytest.MonkeyPatch, fake_portfolio_service: FakePortfolioService
+) -> None:
+    monkeypatch.setenv("PORTFOLIO_SERVICE_URL", "http://portfolio.test")
+    adapter = PortfolioAdapter()
+
+    adapter.update_price("BTC/USDT", Decimal("21500"))
+    assert fake_portfolio_service.updated_prices
+    assert fake_portfolio_service.updated_prices[0]["symbol"] == "BTC/USDT"
+    assert fake_portfolio_service.updated_prices[0]["price"] == "21500"
+
+    pnl = adapter.compute_pnl(symbol="BTC/USDT")
+    assert fake_portfolio_service.pnl_requests == [{"symbol": "BTC/USDT"}]
+    assert pnl.total == fake_portfolio_service.pnl.total
+
+    risk = adapter.check_risk()
+    assert risk[0].name == fake_portfolio_service.risk[0].name


### PR DESCRIPTION
## Summary
- replace the portfolio adapter’s use of local trade manager helpers with a REST-backed client that supports remote trade creation, state access, and risk analytics
- extend the portfolio service interface to expose state, pricing, and analytics calls while fixing the TimeframeRequest field order
- add tests exercising the adapter against a mocked portfolio-service endpoint to verify trade creation, position reads, and pnl/risk queries

## Testing
- pytest tests/services/test_portfolio_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68ca199589a08330b1ba13d6dce02f6d