### PR TITLE
Add execution service API and HTTP adapter integration

### DIFF
--- a/crypto_bot/services/adapters/execution.py
+++ b/crypto_bot/services/adapters/execution.py
@@ -1,15 +1,19 @@
-"""Adapter delegating trade execution to the execution microservice."""
+"""Adapter delegating trade execution to the dedicated HTTP microservice."""
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
 import logging
-from threading import Lock
-from typing import Any, Mapping
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 
-from services.execution import ExecutionService as CoreExecutionService
-from services.execution import ExecutionServiceConfig, OrderRequest
+import httpx
 
 from crypto_bot.services.interfaces import (
     ExchangeRequest,
@@ -21,100 +25,368 @@ from crypto_bot.services.interfaces import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_BASE_URL = "http://execution:8006/api/v1/execution"
+_RETRYABLE_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
 
-class ExecutionAdapter(ExecutionService):
-    """Execution adapter backed by :mod:`services.execution`."""
 
-    def __init__(self) -> None:
-        self._services: dict[str, CoreExecutionService] = {}
-        self._lock = Lock()
+class ExecutionApiError(RuntimeError):
+    """Generic failure returned by the execution service API."""
+
+
+class ExecutionAuthError(ExecutionApiError):
+    """Raised when authentication with the execution service fails."""
+
+
+class ExecutionTimeoutError(ExecutionApiError):
+    """Raised when the API reports a timeout while waiting for an event."""
+
+
+@dataclass(slots=True)
+class _RequestOptions:
+    method: str
+    path: str
+    body: bytes
+    params: Optional[Mapping[str, Any]]
+    expected: tuple[int, ...]
+    event: Optional[str]
+    request_timeout: Optional[float]
+
+
+class ExecutionApiClient:
+    """Minimal asynchronous HTTP client for the execution microservice."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        service_token: Optional[str] = None,
+        signing_key: Optional[str] = None,
+        timeout: Optional[float] = None,
+        ack_timeout: Optional[float] = None,
+        fill_timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+        retry_backoff: Optional[float] = None,
+        client: Optional[httpx.AsyncClient] = None,
+        sync_client: Optional[httpx.Client] = None,
+    ) -> None:
+        self.base_url = base_url or os.getenv("EXECUTION_SERVICE_URL", _DEFAULT_BASE_URL)
+        self._url = httpx.URL(self.base_url)
+        self._base_path = self._url.raw_path.decode("utf-8") if self._url.raw_path else self._url.path
+        if not self._base_path:
+            self._base_path = ""
+        self.service_token = service_token or os.getenv("EXECUTION_SERVICE_TOKEN", "")
+        signing_secret = signing_key or os.getenv("EXECUTION_SERVICE_SIGNING_KEY")
+        self._signing_key = signing_secret.encode("utf-8") if signing_secret else None
+        self.timeout = (
+            timeout
+            if timeout is not None
+            else float(os.getenv("EXECUTION_SERVICE_TIMEOUT", "10"))
+        )
+        self.ack_timeout = (
+            ack_timeout
+            if ack_timeout is not None
+            else float(os.getenv("EXECUTION_SERVICE_ACK_TIMEOUT", "15"))
+        )
+        self.fill_timeout = (
+            fill_timeout
+            if fill_timeout is not None
+            else float(os.getenv("EXECUTION_SERVICE_FILL_TIMEOUT", "60"))
+        )
+        self.retries = (
+            retries if retries is not None else int(os.getenv("EXECUTION_SERVICE_RETRIES", "3"))
+        )
+        self.retry_backoff = (
+            retry_backoff
+            if retry_backoff is not None
+            else float(os.getenv("EXECUTION_SERVICE_RETRY_BACKOFF", "0.5"))
+        )
+        self._client = client or httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
+        self._owns_client = client is None
+        self._sync_client = sync_client
+        self._timeout_margin = 1.0
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
 
     # ------------------------------------------------------------------
-    # Helpers
+    # Core HTTP helpers
     # ------------------------------------------------------------------
 
-    def _config_key(self, config: Mapping[str, Any] | None) -> str:
-        payload = json.dumps(dict(config or {}), sort_keys=True, default=str)
+    @staticmethod
+    def _serialize_body(payload: Optional[Mapping[str, Any]]) -> bytes:
+        if payload is None:
+            return b""
+        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    def _full_path(self, path: str) -> str:
+        suffix = path if path.startswith("/") else f"/{path}"
+        base = self._base_path.rstrip("/")
+        full = f"{base}{suffix}" if base else suffix
+        if not full.startswith("/"):
+            full = f"/{full}"
+        return full
+
+    def _build_headers(self, options: _RequestOptions) -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if options.body:
+            headers["Content-Type"] = "application/json"
+        if self.service_token:
+            headers["X-Service-Token"] = self.service_token
+        if self._signing_key is not None:
+            timestamp = str(int(time.time()))
+            message = f"{timestamp}|{options.method.upper()}|{self._full_path(options.path)}|{options.body.decode('utf-8')}"
+            signature = hmac.new(self._signing_key, message.encode("utf-8"), hashlib.sha256).hexdigest()
+            headers["X-Request-Timestamp"] = timestamp
+            headers["X-Request-Signature"] = signature
+        return headers
+
+    def _prepare_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_payload: Optional[Mapping[str, Any]] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        expected: tuple[int, ...] = (200,),
+        event: Optional[str] = None,
+        request_timeout: Optional[float] = None,
+    ) -> _RequestOptions:
+        body = self._serialize_body(json_payload)
+        return _RequestOptions(
+            method=method,
+            path=path,
+            body=body,
+            params=params,
+            expected=expected,
+            event=event,
+            request_timeout=request_timeout,
+        )
+
+    def _extract_error(self, response: httpx.Response) -> str:
+        try:
+            payload = response.json()
+            if isinstance(payload, Mapping) and "detail" in payload:
+                detail = payload["detail"]
+                if isinstance(detail, (str, bytes)):
+                    return detail if isinstance(detail, str) else detail.decode("utf-8")
+        except ValueError:
+            pass
+        return response.text or f"HTTP {response.status_code}"
+
+    async def _request(self, options: _RequestOptions) -> httpx.Response:
+        backoff = self.retry_backoff
+        for attempt in range(max(1, self.retries)):
+            headers = self._build_headers(options)
+            try:
+                response = await self._client.request(
+                    options.method,
+                    options.path,
+                    params=options.params,
+                    content=options.body or None,
+                    headers=headers,
+                    timeout=options.request_timeout or self.timeout,
+                )
+            except httpx.RequestError as exc:
+                if attempt >= self.retries - 1:
+                    raise ExecutionApiError(f"Execution service request failed: {exc}") from exc
+                await asyncio.sleep(backoff)
+                backoff *= 2
+                continue
+            if response.status_code in options.expected:
+                return response
+            if response.status_code in {401, 403}:
+                raise ExecutionAuthError(self._extract_error(response))
+            if response.status_code == 504 and options.event:
+                raise ExecutionTimeoutError(f"Timeout waiting for {options.event}")
+            if response.status_code in _RETRYABLE_STATUS_CODES and attempt < self.retries - 1:
+                await asyncio.sleep(backoff)
+                backoff *= 2
+                continue
+            raise ExecutionApiError(self._extract_error(response))
+        raise ExecutionApiError("Execution service request exhausted retries")
+
+    def _request_sync(self, options: _RequestOptions) -> httpx.Response:
+        client = self._sync_client or httpx.Client(base_url=self.base_url, timeout=self.timeout)
+        owns_client = self._sync_client is None
+        backoff = self.retry_backoff
+        try:
+            for attempt in range(max(1, self.retries)):
+                headers = self._build_headers(options)
+                try:
+                    response = client.request(
+                        options.method,
+                        options.path,
+                        params=options.params,
+                        content=options.body or None,
+                        headers=headers,
+                        timeout=options.request_timeout or self.timeout,
+                    )
+                except httpx.RequestError as exc:
+                    if attempt >= self.retries - 1:
+                        raise ExecutionApiError(f"Execution service request failed: {exc}") from exc
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                if response.status_code in options.expected:
+                    return response
+                if response.status_code in {401, 403}:
+                    raise ExecutionAuthError(self._extract_error(response))
+                if response.status_code in _RETRYABLE_STATUS_CODES and attempt < self.retries - 1:
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                raise ExecutionApiError(self._extract_error(response))
+        finally:
+            if owns_client:
+                client.close()
+        raise ExecutionApiError("Execution service request exhausted retries")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def ensure_exchange(self, config: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+        options = self._prepare_request(
+            "POST",
+            "/exchanges",
+            json_payload={"config": dict(config or {})},
+            expected=(200,),
+        )
+        response = self._request_sync(options)
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - defensive guardrail
+            raise ExecutionApiError("Invalid JSON returned from execution service") from exc
         return payload
 
-    def _get_service(self, config: Mapping[str, Any] | None) -> CoreExecutionService:
-        key = self._config_key(config)
-        with self._lock:
-            service = self._services.get(key)
-            if service is None:
-                service = CoreExecutionService(ExecutionServiceConfig.from_mapping(config or {}))
-                # Ensure connectivity is established eagerly for deterministic errors
-                service.ensure_session()
-                self._services[key] = service
-        return service
+    async def ensure_exchange_async(self, config: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+        options = self._prepare_request(
+            "POST",
+            "/exchanges",
+            json_payload={"config": dict(config or {})},
+            expected=(200,),
+        )
+        response = await self._request(options)
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - defensive guardrail
+            raise ExecutionApiError("Invalid JSON returned from execution service") from exc
+        return payload
 
-    # ------------------------------------------------------------------
-    # Protocol implementation
-    # ------------------------------------------------------------------
+    async def submit_order(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        options = self._prepare_request(
+            "POST",
+            "/orders",
+            json_payload=payload,
+            expected=(202,),
+        )
+        response = await self._request(options)
+        return response.json() if response.content else {}
+
+    async def wait_for_ack(self, client_order_id: str, timeout: Optional[float]) -> Mapping[str, Any]:
+        params: Dict[str, Any] = {"wait_for": "ack"}
+        if timeout is not None:
+            params["timeout"] = timeout
+        options = self._prepare_request(
+            "GET",
+            f"/orders/{client_order_id}/events",
+            params=params,
+            expected=(200,),
+            event="ack",
+            request_timeout=(timeout or self.ack_timeout) + self._timeout_margin,
+        )
+        response = await self._request(options)
+        data = response.json()
+        return data.get("data", data)
+
+    async def wait_for_fill(self, client_order_id: str, timeout: Optional[float]) -> Mapping[str, Any]:
+        params: Dict[str, Any] = {"wait_for": "fill"}
+        if timeout is not None:
+            params["timeout"] = timeout
+        options = self._prepare_request(
+            "GET",
+            f"/orders/{client_order_id}/events",
+            params=params,
+            expected=(200,),
+            event="fill",
+            request_timeout=(timeout or self.fill_timeout) + self._timeout_margin,
+        )
+        response = await self._request(options)
+        data = response.json()
+        return data.get("data", data)
+
+
+class ExecutionAdapter(ExecutionService):
+    """Execution adapter backed by the HTTP execution microservice."""
+
+    def __init__(self, client: Optional[ExecutionApiClient] = None) -> None:
+        self._client = client or ExecutionApiClient()
+
+    @staticmethod
+    def _generate_client_order_id(config: Optional[Mapping[str, Any]]) -> str:
+        base = "exec"
+        if isinstance(config, Mapping):
+            prefix = config.get("client_prefix")
+            if isinstance(prefix, str) and prefix:
+                base = prefix
+            else:
+                exchange_cfg = config.get("exchange")
+                if isinstance(exchange_cfg, Mapping):
+                    nested_prefix = exchange_cfg.get("client_prefix")
+                    if isinstance(nested_prefix, str) and nested_prefix:
+                        base = nested_prefix
+        return f"{base}-{uuid.uuid4().hex}"
+
+    @staticmethod
+    def _resolve_timeout(config: Optional[Mapping[str, Any]], key: str, default: float) -> float:
+        if not isinstance(config, Mapping):
+            return default
+        value = config.get(key)
+        if value is None:
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):  # pragma: no cover - invalid config
+            logger.warning("Invalid %s override: %r", key, value)
+            return default
 
     def create_exchange(self, request: ExchangeRequest) -> ExchangeResponse:
-        service = self._get_service(request.config)
-        exchange, ws_client = service.create_exchange()
-        return ExchangeResponse(exchange=exchange, ws_client=ws_client)
+        metadata = self._client.ensure_exchange(request.config)
+        return ExchangeResponse(exchange=metadata, ws_client=None)
 
     async def execute_trade(self, request: TradeExecutionRequest) -> TradeExecutionResponse:
-        service = self._get_service(request.config)
-        client_order_id = service.generate_client_order_id()
-        ack_subscription = service.subscribe_acks()
-        fill_subscription = service.subscribe_fills()
+        config: MutableMapping[str, Any] = dict(request.config or {})
+        client_order_id = self._generate_client_order_id(config)
+        order_payload: Dict[str, Any] = {
+            "symbol": request.symbol,
+            "side": request.side,
+            "amount": request.amount,
+            "client_order_id": client_order_id,
+            "dry_run": request.dry_run,
+            "use_websocket": request.use_websocket,
+            "score": request.score,
+            "config": config,
+            "metadata": {"source": "crypto_bot"},
+        }
+        submission = await self._client.submit_order(order_payload)
+        client_order_id = submission.get("client_order_id", client_order_id)
+        ack_timeout = self._resolve_timeout(config, "ack_timeout", self._client.ack_timeout)
         try:
-            order_request = OrderRequest(
-                symbol=request.symbol,
-                side=request.side,
-                amount=request.amount,
-                client_order_id=client_order_id,
-                dry_run=request.dry_run,
-                use_websocket=request.use_websocket,
-                score=request.score,
-                config=dict(request.config or {}),
-                notifier=request.notifier,
-                metadata={"source": "crypto_bot"},
-            )
-            await service.submit_order(order_request)
-            ack = await self._await_ack(ack_subscription, client_order_id, request.config)
-            if not ack.accepted:
-                logger.warning("Order %s rejected: %s", client_order_id, ack.reason)
-                return TradeExecutionResponse(order={})
-            fill = await self._await_fill(fill_subscription, client_order_id, request.config)
-            if not fill.success or not fill.order:
-                logger.warning("Order %s failed: %s", client_order_id, fill.error)
-                return TradeExecutionResponse(order=fill.order or {})
-            return TradeExecutionResponse(order=fill.order)
-        finally:
-            ack_subscription.close()
-            fill_subscription.close()
-
-    # ------------------------------------------------------------------
-    # Event helpers
-    # ------------------------------------------------------------------
-
-    async def _await_ack(
-        self,
-        subscription,
-        client_order_id: str,
-        config: Mapping[str, Any] | None,
-    ):
-        timeout = float((config or {}).get("ack_timeout", 15.0))
-        while True:
-            ack = await asyncio.wait_for(subscription.get(), timeout=timeout)
-            if ack.client_order_id != client_order_id:
-                continue
-            return ack
-
-    async def _await_fill(
-        self,
-        subscription,
-        client_order_id: str,
-        config: Mapping[str, Any] | None,
-    ):
-        timeout = float((config or {}).get("fill_timeout", 60.0))
-        while True:
-            fill = await asyncio.wait_for(subscription.get(), timeout=timeout)
-            if fill.client_order_id != client_order_id:
-                continue
-            return fill
+            ack = await self._client.wait_for_ack(client_order_id, ack_timeout)
+        except ExecutionTimeoutError:
+            logger.warning("Timed out waiting for acknowledgement of %s", client_order_id)
+            return TradeExecutionResponse(order={})
+        if not ack.get("accepted", False):
+            logger.warning("Order %s rejected: %s", client_order_id, ack.get("reason"))
+            return TradeExecutionResponse(order={})
+        fill_timeout = self._resolve_timeout(config, "fill_timeout", self._client.fill_timeout)
+        try:
+            fill = await self._client.wait_for_fill(client_order_id, fill_timeout)
+        except ExecutionTimeoutError:
+            logger.warning("Timed out waiting for fill of %s", client_order_id)
+            return TradeExecutionResponse(order={})
+        if not fill.get("success", False):
+            logger.warning("Order %s failed: %s", client_order_id, fill.get("error"))
+            return TradeExecutionResponse(order=fill.get("order", {}))
+        return TradeExecutionResponse(order=fill.get("order", {}))

--- a/env_local_example
+++ b/env_local_example
@@ -34,6 +34,11 @@ MAX_OPEN_POSITIONS=5
 MAX_RISK_PER_TRADE=0.05
 POSITION_SIZE_PCT=0.1
 
+# Execution Service (microservice)
+EXECUTION_SERVICE_URL=http://localhost:8006/api/v1/execution
+EXECUTION_SERVICE_TOKEN=insecure-local-token-execution
+EXECUTION_SERVICE_SIGNING_KEY=local-dev-signing-key
+
 # Telegram (Disabled for local testing)
 TELEGRAM_ENABLED=false
 TELEGRAM_TOKEN=

--- a/microservice_architecture.yaml
+++ b/microservice_architecture.yaml
@@ -94,6 +94,14 @@ services:
       - Order status monitoring
       - Trade execution
       - WebSocket trading
+      - REST API for exchange creation and order lifecycle streaming
+    interfaces:
+      - POST /api/v1/execution/exchanges
+      - POST /api/v1/execution/orders
+      - GET /api/v1/execution/orders/{client_order_id}/events
+    authentication:
+      service_token: EXECUTION_SERVICE_TOKEN
+      signing_key: EXECUTION_SERVICE_SIGNING_KEY
     dependencies:
       - redis_cache
       - monitoring

--- a/services/execution/__init__.py
+++ b/services/execution/__init__.py
@@ -2,9 +2,11 @@
 
 from .config import (
     CredentialsConfig,
+    ExecutionApiSettings,
     ExecutionServiceConfig,
     MonitoringConfig,
     TelegramConfig,
+    get_execution_api_settings,
 )
 from .models import (
     OrderAck,
@@ -17,6 +19,7 @@ from .service import ExecutionService
 
 __all__ = [
     "CredentialsConfig",
+    "ExecutionApiSettings",
     "ExecutionService",
     "ExecutionServiceConfig",
     "MonitoringConfig",
@@ -25,5 +28,6 @@ __all__ = [
     "OrderRequest",
     "SecretLoader",
     "SecretRef",
+    "get_execution_api_settings",
     "TelegramConfig",
 ]

--- a/services/execution/app.py
+++ b/services/execution/app.py
@@ -1,0 +1,439 @@
+"""FastAPI application exposing the execution service over HTTP."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import logging
+import time
+from asyncio import Lock
+from contextlib import asynccontextmanager, suppress
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel, Field
+
+from .config import ExecutionApiSettings, ExecutionServiceConfig, get_execution_api_settings
+from .models import OrderAck, OrderFill, OrderRequest
+from .service import ExecutionService
+
+LOGGER = logging.getLogger("services.execution.api")
+
+
+class ExchangeCreatePayload(BaseModel):
+    """Incoming payload for creating (or ensuring) an exchange session."""
+
+    config: Optional[Dict[str, Any]] = Field(default=None)
+
+
+class ExchangeCreateResponse(BaseModel):
+    """Metadata returned after ensuring an exchange session exists."""
+
+    status: str = Field(default="ready")
+    config_hash: str
+    exchange_id: Optional[str] = None
+
+
+class OrderSubmitPayload(BaseModel):
+    """Incoming payload describing an order submission."""
+
+    symbol: str
+    side: str
+    amount: float
+    client_order_id: Optional[str] = None
+    dry_run: Optional[bool] = None
+    use_websocket: Optional[bool] = None
+    score: Optional[float] = Field(default=None)
+    config: Optional[Dict[str, Any]] = Field(default=None)
+    metadata: Optional[Dict[str, Any]] = Field(default=None)
+
+
+class OrderSubmitResponse(BaseModel):
+    """Response returned after an order submission request."""
+
+    client_order_id: str
+    status: str = Field(default="submitted")
+
+
+class OrderEventResponse(BaseModel):
+    """Single acknowledgement or fill event payload."""
+
+    type: str = Field(pattern=r"^(ack|fill)$")
+    data: Dict[str, Any]
+
+
+class ExecutionApplicationState:
+    """Holds cached execution service instances keyed by configuration."""
+
+    def __init__(self, settings: ExecutionApiSettings) -> None:
+        self.settings = settings
+        self._services: Dict[str, ExecutionService] = {}
+        self._service_lock = Lock()
+        self._order_index: Dict[str, str] = {}
+        self._order_lock = Lock()
+        self._ack_cache: Dict[str, OrderAck] = {}
+        self._fill_cache: Dict[str, OrderFill] = {}
+        self._order_tasks: Dict[str, list[asyncio.Task[Any]]] = {}
+
+    @staticmethod
+    def _config_key(config: Optional[Mapping[str, Any]]) -> str:
+        payload = dict(config or {})
+        return json.dumps(payload, sort_keys=True, default=str)
+
+    async def get_service(
+        self, config: Optional[Mapping[str, Any]]
+    ) -> tuple[str, ExecutionService]:
+        key = self._config_key(config)
+        async with self._service_lock:
+            service = self._services.get(key)
+            if service is None:
+                service = ExecutionService(ExecutionServiceConfig.from_mapping(config or {}))
+                service.ensure_session()
+                self._services[key] = service
+        return key, service
+
+    async def register_order(
+        self, client_order_id: str, config_key: str, service: ExecutionService
+    ) -> None:
+        async with self._order_lock:
+            self._order_index[client_order_id] = config_key
+            self._ack_cache.pop(client_order_id, None)
+            self._fill_cache.pop(client_order_id, None)
+        ack_task = asyncio.create_task(self._capture_ack(service, client_order_id))
+        fill_task = asyncio.create_task(self._capture_fill(service, client_order_id))
+        async with self._order_lock:
+            self._order_tasks[client_order_id] = [ack_task, fill_task]
+        await asyncio.sleep(0)
+
+    async def resolve_order_service(self, client_order_id: str) -> ExecutionService:
+        async with self._order_lock:
+            config_key = self._order_index.get(client_order_id)
+        if not config_key:
+            raise KeyError(client_order_id)
+        async with self._service_lock:
+            service = self._services.get(config_key)
+        if service is None:
+            raise KeyError(client_order_id)
+        return service
+
+    async def clear_order(self, client_order_id: str) -> None:
+        tasks: list[asyncio.Task[Any]]
+        async with self._order_lock:
+            self._order_index.pop(client_order_id, None)
+            self._ack_cache.pop(client_order_id, None)
+            self._fill_cache.pop(client_order_id, None)
+            tasks = self._order_tasks.pop(client_order_id, [])
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def consume_ack(self, client_order_id: str) -> Optional[OrderAck]:
+        async with self._order_lock:
+            return self._ack_cache.pop(client_order_id, None)
+
+    async def consume_fill(self, client_order_id: str) -> Optional[OrderFill]:
+        async with self._order_lock:
+            return self._fill_cache.pop(client_order_id, None)
+
+    async def _capture_ack(self, service: ExecutionService, order_id: str) -> None:
+        subscription = service.subscribe_acks()
+        try:
+            while True:
+                ack = await subscription.get()
+                if ack.client_order_id != order_id:
+                    continue
+                async with self._order_lock:
+                    self._ack_cache[order_id] = ack
+                return
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            raise
+        finally:
+            subscription.close()
+
+    async def _capture_fill(self, service: ExecutionService, order_id: str) -> None:
+        subscription = service.subscribe_fills()
+        try:
+            while True:
+                fill = await subscription.get()
+                if fill.client_order_id != order_id:
+                    continue
+                async with self._order_lock:
+                    self._fill_cache[order_id] = fill
+                return
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            raise
+        finally:
+            subscription.close()
+
+    async def aclose(self) -> None:
+        async with self._service_lock:
+            services = list(self._services.values())
+            self._services.clear()
+        async with self._order_lock:
+            pending = list(self._order_tasks.values())
+            self._order_tasks.clear()
+        for tasks in pending:
+            for task in tasks:
+                task.cancel()
+        for tasks in pending:
+            for task in tasks:
+                with suppress(asyncio.CancelledError):
+                    await task
+        for service in services:
+            session = getattr(service, "_session", None)
+            if session is None:
+                continue
+            exchange = getattr(session, "exchange", None)
+            close = getattr(exchange, "close", None)
+            if callable(close):
+                if asyncio.iscoroutinefunction(close):  # pragma: no branch - defensive
+                    try:
+                        await close()
+                    except Exception:  # pragma: no cover - best effort cleanup
+                        LOGGER.debug("Failed to close exchange cleanly", exc_info=True)
+                else:
+                    try:
+                        await asyncio.to_thread(close)
+                    except Exception:  # pragma: no cover - best effort cleanup
+                        LOGGER.debug("Failed to close exchange cleanly", exc_info=True)
+            ws_client = getattr(session, "ws_client", None)
+            ws_close = getattr(ws_client, "close", None)
+            if callable(ws_close):
+                try:
+                    result = ws_close()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:  # pragma: no cover - best effort cleanup
+                    LOGGER.debug("Failed to close websocket client", exc_info=True)
+
+
+def _ack_to_dict(ack: OrderAck) -> Dict[str, Any]:
+    return {
+        "client_order_id": ack.client_order_id,
+        "accepted": ack.accepted,
+        "reason": ack.reason,
+        "timestamp": ack.timestamp,
+        "metadata": dict(ack.metadata),
+    }
+
+
+def _fill_to_dict(fill: OrderFill) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "client_order_id": fill.client_order_id,
+        "success": fill.success,
+        "error": fill.error,
+        "timestamp": fill.timestamp,
+        "metadata": dict(fill.metadata),
+    }
+    if fill.order is not None:
+        payload["order"] = jsonable_encoder(fill.order)
+    return payload
+
+
+async def get_state(request: Request) -> ExecutionApplicationState:
+    state: Optional[ExecutionApplicationState] = getattr(
+        request.app.state, "execution_state", None
+    )
+    if state is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Execution service unavailable",
+        )
+    return state
+
+
+async def _verify_signature(
+    request: Request, settings: ExecutionApiSettings
+) -> None:
+    if not settings.signing_key:
+        return
+    provided = request.headers.get("x-request-signature")
+    timestamp_header = request.headers.get("x-request-timestamp")
+    if not provided or not timestamp_header:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing signature")
+    try:
+        timestamp = int(timestamp_header)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature timestamp") from exc
+    now = int(time.time())
+    if abs(now - timestamp) > settings.signature_ttl_seconds:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature expired")
+    body = await request.body()
+    payload = f"{timestamp}|{request.method.upper()}|{request.url.path}|{body.decode('utf-8')}"
+    expected = hmac.new(
+        settings.signing_key.encode("utf-8"), payload.encode("utf-8"), digestmod="sha256"
+    ).hexdigest()
+    if not hmac.compare_digest(expected, provided):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature")
+
+
+async def authorize_request(
+    request: Request, state: ExecutionApplicationState = Depends(get_state)
+) -> None:
+    settings = state.settings
+    token = request.headers.get("x-service-token")
+    if settings.service_token and not hmac.compare_digest(
+        settings.service_token, token or ""
+    ):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid service token")
+    await _verify_signature(request, settings)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_execution_api_settings()
+    logging.getLogger().setLevel(settings.log_level.upper())
+    state = ExecutionApplicationState(settings)
+    app.state.execution_state = state
+    try:
+        yield
+    finally:
+        await state.aclose()
+
+
+def create_app() -> FastAPI:
+    settings = get_execution_api_settings()
+    app = FastAPI(title="Execution Service", lifespan=lifespan)
+    router = APIRouter(prefix=settings.base_path)
+
+    @router.post(
+        "/exchanges",
+        response_model=ExchangeCreateResponse,
+        dependencies=[Depends(authorize_request)],
+    )
+    async def create_exchange_endpoint(
+        payload: ExchangeCreatePayload, state: ExecutionApplicationState = Depends(get_state)
+    ) -> ExchangeCreateResponse:
+        config = payload.config or {}
+        _, service = await state.get_service(config)
+        session = service.ensure_session()
+        exchange = getattr(session.exchange, "id", None)
+        return ExchangeCreateResponse(
+            status="ready",
+            config_hash=session.config_hash,
+            exchange_id=str(exchange) if exchange else None,
+        )
+
+    @router.post(
+        "/orders",
+        response_model=OrderSubmitResponse,
+        status_code=status.HTTP_202_ACCEPTED,
+        dependencies=[Depends(authorize_request)],
+    )
+    async def submit_order_endpoint(
+        payload: OrderSubmitPayload, state: ExecutionApplicationState = Depends(get_state)
+    ) -> OrderSubmitResponse:
+        config = payload.config or {}
+        config_key, service = await state.get_service(config)
+        client_order_id = payload.client_order_id or service.generate_client_order_id()
+        await state.register_order(client_order_id, config_key, service)
+        metadata: MutableMapping[str, Any] = dict(payload.metadata or {})
+        metadata.setdefault("source", "execution-api")
+        request_payload = OrderRequest(
+            symbol=payload.symbol,
+            side=payload.side,
+            amount=payload.amount,
+            client_order_id=client_order_id,
+            dry_run=payload.dry_run if payload.dry_run is not None else service._config.dry_run,
+            use_websocket=
+                payload.use_websocket if payload.use_websocket is not None else service._config.use_websocket,
+            score=payload.score or 0.0,
+            config=dict(config),
+            metadata=metadata,
+        )
+        try:
+            await service.submit_order(request_payload)
+        except Exception:
+            await state.clear_order(client_order_id)
+            LOGGER.exception("Order submission failed for %s", client_order_id)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Order submission failed",
+            )
+        return OrderSubmitResponse(client_order_id=client_order_id)
+
+    @router.get(
+        "/orders/{client_order_id}/events",
+        response_model=OrderEventResponse,
+        dependencies=[Depends(authorize_request)],
+    )
+    async def poll_order_events(
+        client_order_id: str,
+        wait_for: str = "ack",
+        timeout: Optional[float] = None,
+        state: ExecutionApplicationState = Depends(get_state),
+    ) -> OrderEventResponse:
+        if wait_for not in {"ack", "fill"}:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported event type")
+        try:
+            service = await state.resolve_order_service(client_order_id)
+        except KeyError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown order")
+        if wait_for == "ack":
+            cached_ack = await state.consume_ack(client_order_id)
+            if cached_ack is not None:
+                return OrderEventResponse(type="ack", data=_ack_to_dict(cached_ack))
+            ack_from_service = service.pop_ack(client_order_id)
+            if ack_from_service is not None:
+                return OrderEventResponse(type="ack", data=_ack_to_dict(ack_from_service))
+        else:
+            cached_fill = await state.consume_fill(client_order_id)
+            if cached_fill is not None:
+                await state.clear_order(client_order_id)
+                return OrderEventResponse(type="fill", data=_fill_to_dict(cached_fill))
+            fill_from_service = service.get_fill(client_order_id)
+            if fill_from_service is not None:
+                await state.clear_order(client_order_id)
+                return OrderEventResponse(type="fill", data=_fill_to_dict(fill_from_service))
+        subscription = (
+            service.subscribe_acks() if wait_for == "ack" else service.subscribe_fills()
+        )
+        timeout_value = timeout
+        if timeout_value is None:
+            timeout_value = (
+                state.settings.ack_timeout if wait_for == "ack" else state.settings.fill_timeout
+            )
+        try:
+            while True:
+                event = await asyncio.wait_for(subscription.get(), timeout=timeout_value)
+                if event.client_order_id != client_order_id:
+                    continue
+                if isinstance(event, OrderAck):
+                    return OrderEventResponse(type="ack", data=_ack_to_dict(event))
+                if isinstance(event, OrderFill):
+                    await state.clear_order(client_order_id)
+                    return OrderEventResponse(type="fill", data=_fill_to_dict(event))
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail=f"Timeout waiting for {wait_for}",
+            ) from exc
+        finally:
+            subscription.close()
+
+    app.include_router(router)
+
+    @app.get("/health")
+    async def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readiness")
+    async def readiness(state: ExecutionApplicationState = Depends(get_state)) -> Dict[str, Any]:
+        return {
+            "status": "ready",
+            "services": len(state._services),
+        }
+
+    return app
+
+
+app = create_app()
+
+__all__ = [
+    "app",
+    "create_app",
+]

--- a/services/execution/main.py
+++ b/services/execution/main.py
@@ -1,0 +1,20 @@
+"""Entrypoint for running the execution FastAPI service."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from .app import create_app
+from .config import get_execution_api_settings
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    settings = get_execution_api_settings()
+    uvicorn.run(
+        "services.execution.main:app",
+        host=settings.host,
+        port=settings.port,
+        reload=False,
+    )

--- a/tests/services/test_execution_adapter.py
+++ b/tests/services/test_execution_adapter.py
@@ -1,0 +1,140 @@
+import asyncio
+from typing import Any, Dict
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "crypto_bot" / "services" / "adapters" / "execution.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("execution_adapter_test", MODULE_PATH)
+assert MODULE_SPEC and MODULE_SPEC.loader  # sanity check for test setup
+execution_module = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = execution_module
+MODULE_SPEC.loader.exec_module(execution_module)
+
+ExecutionAdapter = execution_module.ExecutionAdapter
+ExecutionApiClient = execution_module.ExecutionApiClient
+
+from crypto_bot.services.interfaces import ExchangeRequest, TradeExecutionRequest
+from services.execution.config import get_execution_api_settings
+
+
+class DummyExchange:
+    id = "dummy"
+
+    def close(self) -> None:  # pragma: no cover - cleanup helper
+        pass
+
+
+@pytest.fixture(autouse=True)
+def clear_execution_settings_cache(monkeypatch):
+    monkeypatch.setenv("EXECUTION_SERVICE_TOKEN", "test-token")
+    monkeypatch.setenv("EXECUTION_SERVICE_SIGNING_KEY", "test-secret")
+    get_execution_api_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def execution_app(monkeypatch):
+    from services.execution.app import create_app
+
+    async def fake_execute_trade_async(
+        exchange: Any,
+        ws_client: Any,
+        symbol: str,
+        side: str,
+        amount: float,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        return {
+            "id": "order-1",
+            "symbol": symbol,
+            "side": side,
+            "amount": amount,
+            "status": "closed",
+        }
+
+    def fake_get_exchange(config):
+        return DummyExchange(), None
+
+    monkeypatch.setattr(
+        "services.execution.exchange.get_exchange",
+        fake_get_exchange,
+    )
+    monkeypatch.setattr(
+        "services.execution.service.execute_trade_async",
+        fake_execute_trade_async,
+    )
+    app = create_app()
+    return app
+
+
+@pytest_asyncio.fixture
+async def execution_client(execution_app):
+    async with execution_app.router.lifespan_context(execution_app):
+        transport = httpx.ASGITransport(app=execution_app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver/api/v1/execution"
+        ) as http_client:
+            yield http_client
+
+
+@pytest.mark.asyncio
+async def test_adapter_executes_trade_via_http(execution_client):
+    client = ExecutionApiClient(
+        base_url="http://testserver/api/v1/execution",
+        service_token="test-token",
+        signing_key="test-secret",
+        ack_timeout=2.0,
+        fill_timeout=2.0,
+        client=execution_client,
+    )
+    metadata = await client.ensure_exchange_async({"client_prefix": "unit"})
+    assert metadata["status"] == "ready"
+    adapter = ExecutionAdapter(client=client)
+    request = TradeExecutionRequest(
+        exchange=None,
+        ws_client=None,
+        symbol="BTC/USD",
+        side="buy",
+        amount=1.25,
+        dry_run=False,
+        use_websocket=False,
+        config={"client_prefix": "unit"},
+    )
+    result = await adapter.execute_trade(request)
+    assert result.order["id"] == "order-1"
+    assert result.order["symbol"] == "BTC/USD"
+
+
+@pytest.mark.asyncio
+async def test_ack_and_fill_events_available_after_submission(execution_client):
+    client = ExecutionApiClient(
+        base_url="http://testserver/api/v1/execution",
+        service_token="test-token",
+        signing_key="test-secret",
+        ack_timeout=2.0,
+        fill_timeout=2.0,
+        client=execution_client,
+    )
+    payload = {
+        "symbol": "ETH/USD",
+        "side": "sell",
+        "amount": 2.5,
+        "client_order_id": "test-ack-1",
+        "dry_run": False,
+        "use_websocket": False,
+        "score": 0.0,
+        "config": {"client_prefix": "unit"},
+        "metadata": {"source": "tests"},
+    }
+    await client.submit_order(payload)
+    await asyncio.sleep(0)  # allow acknowledgement task to run
+    ack = await client.wait_for_ack("test-ack-1", timeout=2.0)
+    assert ack["accepted"] is True
+    fill = await client.wait_for_fill("test-ack-1", timeout=2.0)
+    assert fill["success"] is True
+    assert fill["order"]["side"] == "sell"


### PR DESCRIPTION
## Summary
- introduce a FastAPI execution service with endpoints for exchange creation, order submission, and streaming ack/fill retrieval secured by service tokens and request signatures
- expose configuration helpers and request caching so the service can validate signatures and persist acknowledgements for polling clients
- refactor the crypto execution adapter into an HTTP client with retry/signature support and add contract tests covering ack and fill flows
- document execution service routing and environment variables for the API gateway

## Testing
- `pytest tests/services/test_execution_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca203d8e308330bddc233d2ef0eee9