### PR TITLE
Integrate production trading context into trading engine service

### DIFF
--- a/services/trading_engine/__init__.py
+++ b/services/trading_engine/__init__.py
@@ -1,5 +1,15 @@
 """Trading engine service package."""
 
-from .app import app
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["app"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple lazy import
+    if name == "app":
+        from .app import app as application
+
+        return application
+    raise AttributeError(name)

--- a/services/trading_engine/interface.py
+++ b/services/trading_engine/interface.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 """Adaptor that bridges the trading engine service with the shared interface."""
 
+import asyncio
+import copy
 import logging
-from dataclasses import dataclass, field
+from collections import defaultdict
 from datetime import datetime
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+
+from crypto_bot.phase_runner import BotContext
 
 from services.interface_layer.cycle import CycleExecutionResult, TradingCycleInterface
 
@@ -14,16 +18,181 @@ from .phases import DEFAULT_PHASES
 logger = logging.getLogger(__name__)
 
 
-@dataclass
 class CycleContext:
-    """Minimal context passed to cycle phases."""
+    """Adapter that exposes :class:`BotContext` through the service interface."""
 
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    timing: Dict[str, float] = field(default_factory=dict)
-    memory_manager: Optional[Any] = None
+    __slots__ = {"_ctx", "metadata", "timing", "state"}
 
-    def perform_memory_maintenance(self) -> Dict[str, Any]:  # pragma: no cover - simple stub
-        return {}
+    def __init__(
+        self,
+        bot_context: BotContext,
+        *,
+        metadata: Optional[Mapping[str, Any]] = None,
+        state: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        object.__setattr__(self, "_ctx", bot_context)
+        object.__setattr__(self, "metadata", dict(metadata or {}))
+        object.__setattr__(self, "timing", {})
+        object.__setattr__(self, "state", state if state is not None else {})
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._ctx, item)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in self.__slots__:
+            object.__setattr__(self, key, value)
+        else:
+            setattr(self._ctx, key, value)
+
+    def __delattr__(self, item: str) -> None:  # pragma: no cover - defensive
+        if item in self.__slots__:
+            raise AttributeError(f"Cannot delete attribute '{item}'")
+        delattr(self._ctx, item)
+
+    def perform_memory_maintenance(self) -> Dict[str, Any]:
+        return self._ctx.perform_memory_maintenance()
+
+
+class TradingContextBuilder:
+    """Factory that manages a long-lived :class:`BotContext`."""
+
+    def __init__(
+        self,
+        *,
+        services: Any,
+        config: Mapping[str, Any],
+        exchange: Any = None,
+        ws_client: Any = None,
+        risk_manager: Any = None,
+        notifier: Any = None,
+        paper_wallet: Any = None,
+        position_guard: Any = None,
+        trade_manager: Any = None,
+    ) -> None:
+        self._services = services
+        self._config = copy.deepcopy(dict(config))
+        self._exchange = exchange
+        self._ws_client = ws_client
+        self._risk_manager = risk_manager
+        self._notifier = notifier
+        self._paper_wallet = paper_wallet
+        self._position_guard = position_guard
+        self._trade_manager = trade_manager
+        self._bot_context: Optional[BotContext] = None
+        self._state: Dict[str, Any] = {"cycles": 0}
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def __call__(self, metadata: Optional[Mapping[str, Any]] = None) -> CycleContext:
+        ctx = self._ensure_context()
+        self._state["cycles"] = int(self._state.get("cycles", 0)) + 1
+        cycle_meta = dict(metadata or {})
+        cycle_meta.setdefault("cycle_id", self._state["cycles"])
+        cycle_meta.setdefault("config_version", self._config.get("config_version"))
+        return CycleContext(ctx, metadata=cycle_meta, state=self._state)
+
+    @property
+    def context(self) -> BotContext:
+        return self._ensure_context()
+
+    @property
+    def services(self) -> Any:
+        return self._services
+
+    @property
+    def exchange(self) -> Any:
+        return self._exchange
+
+    @property
+    def ws_client(self) -> Any:
+        return self._ws_client
+
+    async def shutdown(self) -> None:
+        """Close any resources owned by the builder."""
+
+        async def _call(func: Callable[[], Any], *, use_thread: bool = False) -> None:
+            try:
+                if use_thread:
+                    await asyncio.to_thread(func)
+                    return
+                result = func()
+                if asyncio.isfuture(result) or asyncio.iscoroutine(result):
+                    await result  # type: ignore[arg-type]
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.debug("Resource cleanup failed", exc_info=True)
+
+        if self._services:
+            market_data = getattr(self._services, "market_data", None)
+            if market_data and hasattr(market_data, "close"):
+                await _call(market_data.close)
+            strategy = getattr(self._services, "strategy", None)
+            if strategy and hasattr(strategy, "aclose"):
+                await _call(strategy.aclose)
+
+        if self._ws_client:
+            if hasattr(self._ws_client, "close_async"):
+                await _call(self._ws_client.close_async)
+            elif hasattr(self._ws_client, "close"):
+                close_func = self._ws_client.close
+                await _call(close_func, use_thread=not asyncio.iscoroutinefunction(close_func))
+
+        if self._exchange and hasattr(self._exchange, "close"):
+            close_func = self._exchange.close
+            await _call(close_func, use_thread=not asyncio.iscoroutinefunction(close_func))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_context(self) -> BotContext:
+        if self._bot_context is not None:
+            return self._bot_context
+
+        positions: Dict[str, Any] = {}
+        if self._trade_manager is not None:
+            try:
+                for pos in self._trade_manager.get_all_positions():  # type: ignore[attr-defined]
+                    symbol = getattr(pos, "symbol", None) or getattr(pos, "id", None)
+                    if not symbol:
+                        continue
+                    entry_price = getattr(pos, "entry_price", None) or getattr(pos, "price", 0.0)
+                    amount = getattr(pos, "total_amount", None) or getattr(pos, "amount", 0.0)
+                    positions[symbol] = {
+                        "symbol": symbol,
+                        "side": getattr(pos, "side", "long"),
+                        "entry_price": float(entry_price or 0.0),
+                        "amount": float(amount or 0.0),
+                    }
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Unable to prime positions from trade manager", exc_info=True)
+
+        config = copy.deepcopy(dict(self._config))
+        ctx = BotContext(
+            positions=positions,
+            df_cache=defaultdict(dict),
+            regime_cache=defaultdict(dict),
+            config=config,
+            exchange=self._exchange,
+            ws_client=self._ws_client,
+            risk_manager=self._risk_manager,
+            notifier=self._notifier,
+            paper_wallet=self._paper_wallet,
+            position_guard=self._position_guard,
+            trade_manager=self._trade_manager,
+            services=self._services,
+        )
+
+        starting_balance = (
+            float(
+                config.get("risk", {}).get("starting_balance")
+                or config.get("paper_wallet", {}).get("initial_balance")
+                or 0.0
+            )
+        )
+        ctx.balance = starting_balance
+        ctx.use_trade_manager_as_source = bool(config.get("use_trade_manager_as_source"))
+        self._bot_context = ctx
+        return ctx
 
 
 class TradingEngineInterface:
@@ -35,10 +204,40 @@ class TradingEngineInterface:
         *,
         clock: Optional[Callable[[], datetime]] = None,
         timer: Optional[Callable[[], float]] = None,
+        services: Any = None,
+        config: Optional[Mapping[str, Any]] = None,
+        exchange: Any = None,
+        ws_client: Any = None,
+        risk_manager: Any = None,
+        notifier: Any = None,
+        paper_wallet: Any = None,
+        position_guard: Any = None,
+        trade_manager: Any = None,
     ) -> None:
         self._phases = list(phases or DEFAULT_PHASES)
         self._runner = TradingCycleInterface(self._phases, clock=clock, timer=timer)
+        self._context_factory = TradingContextBuilder(
+            services=services,
+            config=config or {},
+            exchange=exchange,
+            ws_client=ws_client,
+            risk_manager=risk_manager,
+            notifier=notifier,
+            paper_wallet=paper_wallet,
+            position_guard=position_guard,
+            trade_manager=trade_manager,
+        )
 
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def context(self) -> BotContext:
+        return self._context_factory.context
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def set_phases(self, phases: Iterable) -> None:
         self._phases = list(phases)
         self._runner.set_phases(self._phases)
@@ -46,11 +245,15 @@ class TradingEngineInterface:
     async def run_cycle(self, metadata: Optional[Dict[str, Any]] = None) -> CycleExecutionResult:
         """Execute a single trading cycle and return timing information."""
 
-        context = CycleContext(metadata=dict(metadata or {}))
+        context = self._context_factory(metadata)
         result = await self._runner.run_cycle(context)
         context.timing = result.timings
+        result.metadata.update(context.metadata)
         logger.debug("Trading cycle completed with timings: %s", result.timings)
         return result
 
+    async def shutdown(self) -> None:
+        await self._context_factory.shutdown()
 
-__all__ = ["TradingEngineInterface", "CycleContext"]
+
+__all__ = ["TradingEngineInterface", "CycleContext", "TradingContextBuilder"]

--- a/services/trading_engine/phases.py
+++ b/services/trading_engine/phases.py
@@ -1,48 +1,377 @@
-from __future__ import annotations
-
 """Default phases executed by the trading engine service."""
 
-import asyncio
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Iterable, Mapping, MutableMapping, Optional
+
+import pandas as pd
+
+from crypto_bot.services.interfaces import (
+    CacheUpdateResponse,
+    MultiTimeframeOHLCVRequest,
+    RegimeCacheRequest,
+    StrategyBatchRequest,
+    StrategyBatchResponse,
+    StrategyEvaluationPayload,
+    StrategyEvaluationResult,
+    TokenDiscoveryRequest,
+    TokenDiscoveryResponse,
+    TradeExecutionRequest,
+)
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from .interface import CycleContext
+
+def _unique_symbols(symbols: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for symbol in symbols:
+        if not symbol or symbol in seen:
+            continue
+        seen.add(symbol)
+        ordered.append(symbol)
+    return ordered
 
 
-async def prepare_cycle(context: "CycleContext") -> None:
-    """Record that a new cycle is being prepared."""
+def _select_dataframe(df_cache: Mapping[str, Mapping[str, pd.DataFrame]], symbol: str) -> Optional[pd.DataFrame]:
+    for timeframe, entries in df_cache.items():
+        frame = entries.get(symbol)
+        if isinstance(frame, pd.DataFrame) and not frame.empty:
+            logger.debug("Using %s timeframe for %s", timeframe, symbol)
+            return frame
+    return None
+
+
+def _infer_regime(regime_cache: Mapping[str, Mapping[str, object]], symbol: str, default: str) -> str:
+    for entries in regime_cache.values():
+        data = entries.get(symbol)
+        if isinstance(data, Mapping):
+            regime = data.get("regime") or data.get("label")
+            if isinstance(regime, str) and regime:
+                return regime
+    return default
+
+
+async def prepare_cycle(context) -> None:
+    """Initialise cycle metadata and refresh cached positions."""
 
     context.metadata.setdefault("events", []).append("prepare")
-    await asyncio.sleep(0)
-    logger.debug("Prepared trading cycle with metadata: %s", context.metadata)
-
-
-async def orchestrate_cycle(context: "CycleContext") -> None:
-    """Simulate orchestration work for the trading cycle."""
-
     context.metadata["cycle_started_at"] = datetime.now(timezone.utc).isoformat()
-    await asyncio.sleep(0)
-    logger.debug("Orchestrated trading cycle")
+    context.metadata.setdefault("cycle_sequence", context.state.get("cycles", 0))
+
+    if getattr(context, "trade_manager", None) is not None:
+        try:
+            context.sync_positions_from_trade_manager()
+        except Exception:  # pragma: no cover - defensive logging
+            logger.debug("Position sync failed", exc_info=True)
+
+    open_positions = sorted(getattr(context, "positions", {}).keys())
+    context.metadata["open_positions"] = open_positions
 
 
-async def finalize_cycle(context: "CycleContext") -> None:
-    """Finalize the trading cycle and mark completion time."""
+async def discover_markets(context) -> None:
+    """Build the symbol batch using static configuration and discovery results."""
+
+    config = getattr(context, "config", {}) or {}
+    static_symbols = list(config.get("symbols", []))
+    discovery_cfg = (
+        config.get("enhanced_scanning")
+        or config.get("token_discovery")
+        or {}
+    )
+
+    discovered: list[str] = []
+    discovery = getattr(getattr(context, "services", None), "token_discovery", None)
+    if discovery is not None:
+        try:
+            request = TokenDiscoveryRequest(config=discovery_cfg)
+            response: TokenDiscoveryResponse = await discovery.discover_tokens(request)
+            discovered = list(response.tokens or [])
+        except Exception:  # pragma: no cover - discovery is optional
+            logger.debug("Token discovery failed", exc_info=True)
+
+    combined = _unique_symbols(static_symbols + discovered)
+    batch_size = int(config.get("symbol_batch_size") or len(combined) or 0)
+    if batch_size > 0:
+        combined = combined[:batch_size]
+
+    context.current_batch = combined
+    context.metadata["symbol_batch"] = combined
+
+
+async def load_market_data(context) -> None:
+    """Populate OHLCV and regime caches for the current batch."""
+
+    if not getattr(context, "current_batch", None):
+        logger.debug("No symbols selected for market data update")
+        return
+
+    services = getattr(context, "services", None)
+    market_data = getattr(services, "market_data", None)
+    if market_data is None:
+        logger.debug("Market data service unavailable; skipping cache refresh")
+        return
+
+    config = getattr(context, "config", {}) or {}
+    exchange_id = str(config.get("exchange", "kraken"))
+    market_cfg = config.get("market_data", {})
+    primary_timeframe = market_cfg.get("timeframe", config.get("timeframe", "1h"))
+    extra_timeframes = market_cfg.get("timeframes") or config.get("additional_timeframes", [])
+    limit = int(market_cfg.get("limit", config.get("ohlcv_limit", 250)))
+
+    request = MultiTimeframeOHLCVRequest(
+        exchange_id=exchange_id,
+        cache=context.df_cache,
+        symbols=context.current_batch,
+        config={
+            "timeframe": primary_timeframe,
+            "timeframes": [primary_timeframe, *extra_timeframes],
+        },
+        limit=limit,
+        use_websocket=bool(config.get("use_websocket")),
+        force_websocket_history=bool(config.get("force_websocket_history")),
+        max_concurrent=config.get("max_concurrent_ohlcv"),
+        notifier=getattr(context, "notifier", None),
+    )
+
+    try:
+        response: CacheUpdateResponse = await market_data.update_multi_tf_cache(request)
+        context.df_cache = response.cache
+    except Exception:
+        logger.exception("Failed to update OHLCV cache")
+
+    regime_timeframes = config.get("regime_timeframes")
+    if regime_timeframes:
+        regime_request = RegimeCacheRequest(
+            exchange_id=exchange_id,
+            cache=context.regime_cache,
+            symbols=context.current_batch,
+            config={"timeframes": list(regime_timeframes)},
+            limit=limit,
+            use_websocket=bool(config.get("use_websocket")),
+            force_websocket_history=bool(config.get("force_websocket_history")),
+            max_concurrent=config.get("max_concurrent_ohlcv"),
+            notifier=getattr(context, "notifier", None),
+            df_map=context.df_cache,
+        )
+        try:
+            regime_response: CacheUpdateResponse = await market_data.update_regime_cache(regime_request)
+            context.regime_cache = regime_response.cache
+        except Exception:  # pragma: no cover - advisory
+            logger.debug("Regime cache update failed", exc_info=True)
+
+    context.metadata["market_data_updated"] = len(context.current_batch)
+
+
+async def evaluate_signals(context) -> None:
+    """Invoke the strategy service to generate trading signals."""
+
+    services = getattr(context, "services", None)
+    strategy_service = getattr(services, "strategy", None)
+    if strategy_service is None:
+        logger.debug("Strategy service unavailable; no signal evaluation performed")
+        context.analysis_results = []
+        return
+
+    config = getattr(context, "config", {}) or {}
+    default_regime = config.get("default_regime", "neutral")
+    payloads: list[StrategyEvaluationPayload] = []
+
+    for symbol in context.current_batch:
+        df = _select_dataframe(context.df_cache, symbol)
+        if df is None:
+            continue
+        regime = _infer_regime(context.regime_cache, symbol, default_regime)
+        timeframes: MutableMapping[str, pd.DataFrame] = {}
+        for timeframe, entries in context.df_cache.items():
+            frame = entries.get(symbol)
+            if isinstance(frame, pd.DataFrame) and not frame.empty:
+                timeframes[timeframe] = frame
+        if not timeframes:
+            continue
+        payloads.append(
+            StrategyEvaluationPayload(
+                symbol=symbol,
+                regime=regime,
+                mode=str(config.get("mode", "auto")),
+                timeframes=timeframes,
+                config=config.get("strategy_router", config.get("strategy", {})),
+                metadata={"cycle": context.metadata.get("cycle_sequence")},
+            )
+        )
+
+    if not payloads:
+        context.analysis_results = []
+        context.metadata["analysis_results"] = 0
+        return
+
+    request = StrategyBatchRequest(items=tuple(payloads), metadata={"cycle": context.metadata.get("cycle_sequence")})
+    try:
+        response: StrategyBatchResponse = await strategy_service.evaluate_batch(request)
+    except Exception:
+        logger.exception("Strategy evaluation failed")
+        context.analysis_results = []
+        context.metadata["analysis_results"] = 0
+        return
+
+    results = list(response.results or [])
+    context.analysis_results = results
+    context.metadata["analysis_results"] = len(results)
+    if response.errors:
+        context.metadata["analysis_errors"] = list(response.errors)
+
+
+async def execute_signals(context) -> None:
+    """Run risk checks and dispatch executable orders."""
+
+    results: Iterable[StrategyEvaluationResult] = getattr(context, "analysis_results", []) or []
+    if not results:
+        context.metadata["executed_trades"] = []
+        return
+
+    services = getattr(context, "services", None)
+    execution = getattr(services, "execution", None)
+    if execution is None:
+        logger.debug("Execution service unavailable; no trades placed")
+        context.metadata["executed_trades"] = []
+        return
+
+    risk_manager = getattr(context, "risk_manager", None)
+    balance = float(getattr(context, "balance", 0.0))
+    execution_mode = str((getattr(context, "config", {}) or {}).get("execution_mode", "dry_run"))
+    dry_run = execution_mode.lower() != "live"
+    executed: list[dict[str, object]] = []
+
+    for result in results:
+        direction = (result.direction or "").lower()
+        if direction not in {"long", "short"}:
+            continue
+
+        df = _select_dataframe(context.df_cache, result.symbol)
+        if df is None or df.empty:
+            continue
+        price = float(df["close"].iloc[-1])
+
+        allowed = True
+        reason = ""
+        if risk_manager is not None:
+            try:
+                allowed, reason = risk_manager.allow_trade(df, result.strategy)
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("Risk allow_trade failed for %s", result.symbol, exc_info=True)
+                allowed = True
+        if not allowed:
+            context.metadata.setdefault("skipped_trades", []).append({"symbol": result.symbol, "reason": reason})
+            continue
+
+        size = balance * 0.0
+        if risk_manager is not None:
+            try:
+                size = float(
+                    risk_manager.position_size(
+                        float(result.score or 0.0),
+                        float(balance),
+                        df=df,
+                        atr=result.atr,
+                        price=price,
+                    )
+                )
+            except Exception:  # pragma: no cover - fallback sizing
+                logger.debug("Risk position_size failed for %s", result.symbol, exc_info=True)
+                size = float(balance) * 0.05
+        else:
+            size = float(balance) * 0.05
+
+        if size <= 0:
+            continue
+
+        if hasattr(risk_manager, "can_allocate") and hasattr(risk_manager, "allocate_capital"):
+            try:
+                if not risk_manager.can_allocate(result.strategy or "", size, balance):
+                    continue
+                risk_manager.allocate_capital(result.strategy or "", size)
+            except Exception:  # pragma: no cover - advisory
+                logger.debug("Capital allocation failed for %s", result.symbol, exc_info=True)
+
+        amount = size / price if price else 0.0
+        trade_request = TradeExecutionRequest(
+            exchange=getattr(context, "exchange", None),
+            ws_client=getattr(context, "ws_client", None),
+            symbol=result.symbol,
+            side="buy" if direction == "long" else "sell",
+            amount=float(amount),
+            notifier=getattr(context, "notifier", None),
+            dry_run=dry_run,
+            use_websocket=bool(context.config.get("use_websocket")),
+            config=context.config,
+            score=float(result.score or 0.0),
+        )
+
+        try:
+            response = await execution.execute_trade(trade_request)
+        except Exception:
+            logger.exception("Trade execution failed for %s", result.symbol)
+            continue
+
+        executed.append(
+            {
+                "symbol": result.symbol,
+                "side": trade_request.side,
+                "amount": trade_request.amount,
+                "order": getattr(response, "order", {}),
+                "strategy": result.strategy,
+            }
+        )
+        balance = max(balance - size, 0.0)
+        context.balance = balance
+
+        paper_wallet = getattr(context, "paper_wallet", None)
+        if paper_wallet is not None:
+            try:
+                if direction == "long":
+                    paper_wallet.buy(result.symbol, amount, price)
+                else:
+                    paper_wallet.sell(result.symbol, amount, price)
+            except Exception:  # pragma: no cover - optional path
+                logger.debug("Paper wallet trade failed for %s", result.symbol, exc_info=True)
+
+    context.metadata["executed_trades"] = executed
+    context.metadata["executed_trade_count"] = len(executed)
+
+
+async def finalize_cycle(context) -> None:
+    """Persist summary metadata and refresh derived state."""
 
     context.metadata["cycle_completed_at"] = datetime.now(timezone.utc).isoformat()
-    await asyncio.sleep(0)
-    logger.debug("Finalized trading cycle")
+    context.metadata["balance"] = float(getattr(context, "balance", 0.0))
+
+    if getattr(context, "trade_manager", None) is not None:
+        try:
+            context.sync_positions_from_trade_manager()
+        except Exception:  # pragma: no cover - defensive logging
+            logger.debug("Post-cycle position sync failed", exc_info=True)
+
+    context.metadata["open_positions"] = sorted(getattr(context, "positions", {}).keys())
 
 
-DEFAULT_PHASES = [prepare_cycle, orchestrate_cycle, finalize_cycle]
+DEFAULT_PHASES = [
+    prepare_cycle,
+    discover_markets,
+    load_market_data,
+    evaluate_signals,
+    execute_signals,
+    finalize_cycle,
+]
 
 
 __all__ = [
     "prepare_cycle",
-    "orchestrate_cycle",
+    "discover_markets",
+    "load_market_data",
+    "evaluate_signals",
+    "execute_signals",
     "finalize_cycle",
     "DEFAULT_PHASES",
 ]

--- a/tests/services/test_cycle_context.py
+++ b/tests/services/test_cycle_context.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import sys
+import types
+
+if "pydantic_settings" not in sys.modules:  # pragma: no cover - test scaffold
+    module = types.ModuleType("pydantic_settings")
+
+    class _BaseSettings:  # pragma: no cover - minimal shim
+        model_config = {}
+
+    module.BaseSettings = _BaseSettings
+    module.SettingsConfigDict = dict
+    sys.modules["pydantic_settings"] = module
+
+from services.trading_engine.interface import CycleContext
+from crypto_bot.phase_runner import BotContext
+
+
+class _FakeMemoryManager:
+    def perform_maintenance(self):
+        return {"cleaned": True}
+
+
+def _make_bot_context() -> BotContext:
+    ctx = BotContext(
+        positions={},
+        df_cache={},
+        regime_cache={},
+        config={},
+    )
+    ctx.memory_manager = _FakeMemoryManager()
+    return ctx
+
+
+def test_cycle_context_delegate_attributes() -> None:
+    bot = _make_bot_context()
+    wrapper = CycleContext(bot, metadata={"source": "test"}, state={"cycles": 1})
+
+    wrapper.balance = 125.0
+    assert bot.balance == 125.0
+    assert wrapper.metadata == {"source": "test"}
+
+    wrapper.state["cycles"] = 2
+    assert wrapper.state["cycles"] == 2
+
+    maintenance = wrapper.perform_memory_maintenance()
+    assert maintenance == {"cleaned": True}

--- a/tests/services/test_trading_engine_interface.py
+++ b/tests/services/test_trading_engine_interface.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import sys
+import types
+
+if "pydantic_settings" not in sys.modules:  # pragma: no cover - test scaffold
+    module = types.ModuleType("pydantic_settings")
+
+    class _BaseSettings:  # pragma: no cover - minimal shim
+        model_config = {}
+
+    module.BaseSettings = _BaseSettings
+    module.SettingsConfigDict = dict
+    sys.modules["pydantic_settings"] = module
+
+from crypto_bot.open_position_guard import OpenPositionGuard
+from crypto_bot.services.interfaces import (
+    CacheUpdateResponse,
+    ServiceContainer,
+    StrategyBatchRequest,
+    StrategyBatchResponse,
+    StrategyEvaluationResult,
+    TokenDiscoveryRequest,
+    TokenDiscoveryResponse,
+    TradeExecutionRequest,
+    TradeExecutionResponse,
+)
+from services.trading_engine.interface import TradingEngineInterface
+
+
+class FakeMarketDataService:
+    async def update_multi_tf_cache(self, request: Any) -> CacheUpdateResponse:
+        cache = request.cache
+        timeframe = request.config.get("timeframe", "1h")
+        tf_cache = cache.setdefault(timeframe, {})
+        index = pd.date_range("2024-01-01", periods=32, freq="H", tz="UTC")
+        frame = pd.DataFrame(
+            {
+                "open": [100 + i * 0.1 for i in range(len(index))],
+                "high": [101 + i * 0.1 for i in range(len(index))],
+                "low": [99 + i * 0.1 for i in range(len(index))],
+                "close": [100 + i * 0.1 for i in range(len(index))],
+                "volume": [50 + i for i in range(len(index))],
+            },
+            index=index,
+        )
+        for symbol in request.symbols:
+            tf_cache[symbol] = frame.copy()
+        return CacheUpdateResponse(cache=cache)
+
+    async def update_regime_cache(self, request: Any) -> CacheUpdateResponse:
+        cache = request.cache
+        tf_cache = cache.setdefault("1h", {})
+        for symbol in request.symbols:
+            tf_cache[symbol] = {"regime": "trending"}
+        return CacheUpdateResponse(cache=cache)
+
+
+class FakeStrategyService:
+    def __init__(self) -> None:
+        self.requests: list[StrategyBatchRequest] = []
+
+    async def evaluate_batch(self, request: StrategyBatchRequest) -> StrategyBatchResponse:
+        self.requests.append(request)
+        results: list[StrategyEvaluationResult] = []
+        for payload in request.items:
+            results.append(
+                StrategyEvaluationResult(
+                    symbol=payload.symbol,
+                    regime=payload.regime,
+                    strategy="trend_bot",
+                    score=0.8,
+                    direction="long",
+                    atr=1.5,
+                )
+            )
+        return StrategyBatchResponse(results=tuple(results), errors=tuple())
+
+
+class FakeExecutionService:
+    def __init__(self) -> None:
+        self.requests: list[TradeExecutionRequest] = []
+
+    async def execute_trade(self, request: TradeExecutionRequest) -> TradeExecutionResponse:
+        self.requests.append(request)
+        return TradeExecutionResponse(order={"id": f"order-{len(self.requests)}"})
+
+
+class FakeTokenDiscoveryService:
+    async def discover_tokens(self, request: TokenDiscoveryRequest) -> TokenDiscoveryResponse:
+        return TokenDiscoveryResponse(tokens=["ETH/USD"])
+
+
+class FakePortfolioService:
+    def get_trade_manager(self):  # pragma: no cover - simple stub
+        return None
+
+
+class FakeMonitoringService:
+    def record_scanner_metrics(self, *_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
+        return None
+
+
+class FakeRiskManager:
+    def __init__(self) -> None:
+        self.checked: list[str | None] = []
+
+    def allow_trade(self, df: pd.DataFrame, strategy: str | None = None):
+        self.checked.append(strategy)
+        return True, ""
+
+    def position_size(
+        self,
+        confidence: float,
+        balance: float,
+        df: pd.DataFrame | None = None,
+        atr: float | None = None,
+        price: float | None = None,
+    ) -> float:
+        return balance * 0.2
+
+    def can_allocate(self, strategy: str, amount: float, balance: float) -> bool:
+        return True
+
+    def allocate_capital(self, strategy: str, amount: float) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+@pytest.mark.asyncio
+async def test_trading_engine_run_cycle_executes_real_phases() -> None:
+    services = ServiceContainer(
+        market_data=FakeMarketDataService(),
+        strategy=FakeStrategyService(),
+        portfolio=FakePortfolioService(),
+        execution=FakeExecutionService(),
+        token_discovery=FakeTokenDiscoveryService(),
+        monitoring=FakeMonitoringService(),
+    )
+
+    config = {
+        "symbols": ["BTC/USD"],
+        "timeframe": "1h",
+        "execution_mode": "dry_run",
+        "risk": {"starting_balance": 1000.0},
+    }
+
+    risk_manager = FakeRiskManager()
+
+    interface = TradingEngineInterface(
+        services=services,
+        config=config,
+        exchange=object(),
+        risk_manager=risk_manager,
+        paper_wallet=None,
+        position_guard=OpenPositionGuard(5),
+        trade_manager=None,
+    )
+
+    result = await interface.run_cycle(metadata={"trigger": "unit"})
+
+    assert "prepare_cycle" in result.timings
+    assert services.strategy.requests, "strategy service should be invoked"
+    assert services.execution.requests, "execution service should be invoked"
+    assert services.execution.requests[0].symbol in {"BTC/USD", "ETH/USD"}
+    assert interface.context.analysis_results
+    assert result.metadata["executed_trade_count"] == len(services.execution.requests)
+
+    await interface.shutdown()


### PR DESCRIPTION
## Summary
- wrap the trading engine cycle context around crypto_bot.phase_runner.BotContext so production memory hooks run
- replace stubbed trading phases with implementations that call the real market data, strategy, and execution adapters
- update the FastAPI lifespan to build service dependencies (config, exchange, risk, paper wallet) before wiring the scheduler
- add targeted tests that exercise TradingEngineInterface.run_cycle with stubbed services to verify signal evaluation and trade execution

## Testing
- pytest tests/services/test_cycle_context.py tests/services/test_trading_engine_interface.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca21e1b6d08330b0ea09df189c349d