### PR TITLE
Add observability instrumentation and alerting across services

### DIFF
--- a/services/monitoring/DASHBOARDS.md
+++ b/services/monitoring/DASHBOARDS.md
@@ -1,8 +1,26 @@
 # Grafana Dashboards & Alerting
 
-The following dashboards are designed for Grafana (or any Prometheus compatible
+The following dashboards are designed for Grafana (or any Prometheus-compatible
 visualisation layer). Each panel references the metrics emitted by the
-`services/monitoring` toolkit.
+`services/monitoring` toolkit and the `/metrics` endpoints exposed by every
+microservice and the Flask frontend.
+
+## Prometheus Scrape Targets
+
+Every service now exposes a Prometheus exporter on the same port as its API.
+The consolidated scrape configuration lives in
+[`prometheus.yaml`](./prometheus.yaml).
+
+| Service           | Endpoint                          | Notes |
+|-------------------|-----------------------------------|-------|
+| API Gateway       | `http://api-gateway:8000/metrics` | Includes edge auth and rate limiting metrics. |
+| Trading Engine    | `http://trading-engine:8001/metrics` | Captures cycle orchestration requests. |
+| Market Data       | `http://market-data:8002/metrics` | Observes symbol/ohlcv refresh calls. |
+| Portfolio         | `http://portfolio:8003/metrics`   | Tracks portfolio mutation and risk checks. |
+| Strategy Engine   | `http://strategy-engine:8004/metrics` | Emits strategy evaluation timings. |
+| Token Discovery   | `http://token-discovery:8005/metrics` | Follows discovery scans and scoring. |
+| Execution Service | `http://execution:8006/metrics`   | Measures order submission flow. |
+| Frontend          | `http://frontend:5000/metrics`     | Flask dashboard instrumentation. |
 
 ## 1. Service Golden Signals
 
@@ -13,16 +31,20 @@ visualisation layer). Each panel references the metrics emitted by the
 | Request rate | `sum by (service, method) (increase(legacycoin_http_requests_total[5m]))` | Break down traffic by HTTP method. |
 | Error rate | `sum by (service) (increase(legacycoin_http_request_errors_total[5m]))` | Compare with request rate to derive error percentage. |
 | P95 latency | `histogram_quantile(0.95, sum by (service, method, route, le)(rate(legacycoin_http_request_duration_seconds_bucket[5m])))` | Uses the automatically exported histogram. |
+| Memory usage | `process_resident_memory_bytes{job=~"api-gateway|trading-engine|market-data|portfolio|strategy-engine|token-discovery|execution|frontend"}` | Overlay alert threshold at 1.5 GiB. |
 | In-flight requests | `sum by (service) (increase(legacycoin_http_requests_total[1m]))` | Short window for saturation spikes. |
 
 ### Alerts
 
-* **High error rate** – Trigger when
-  `sum(increase(legacycoin_http_request_errors_total{service="trading-engine"}[5m])) /
-   sum(increase(legacycoin_http_requests_total{service="trading-engine"}[5m])) > 0.05`
-  for 10 minutes.
-* **Elevated latency** – Trigger when the P95 latency exceeds 2s for three
-  consecutive evaluation periods.
+Alerting rules are codified in [`alerts.yaml`](./alerts.yaml) and include:
+
+* **HighMemoryUsage** – fires when `process_resident_memory_bytes` exceeds
+  1.5&nbsp;GiB for five minutes.
+* **ElevatedErrorRate** – raises when the ratio of
+  `legacycoin_http_request_errors_total` to
+  `legacycoin_http_requests_total` is greater than 5% over ten minutes.
+* **HighRequestLatency** – triggers when the 95th percentile response time is
+  above two seconds for five minutes.
 
 ## 2. Trading Pipeline Drill-down
 
@@ -42,12 +64,28 @@ Panels:
 
 ### Alerts
 
-* **Stalled scheduler** – Alert if no `legacycoin_http_requests_total{route="/cycles/run"}` increase occurs for 15 minutes.
+* **Stalled scheduler** – Alert if no
+  `legacycoin_http_requests_total{service="trading-engine", route="/cycles/run"}`
+  increase occurs for 15 minutes.
 * **Slow cycle** – Alert when the `metadata.duration_seconds` field in logs
   exceeds 60 seconds. This can be expressed as a LogQL/Elasticsearch alert:
-  `avg_of_duration > 60` for 3 consecutive intervals.
+  `avg_of_duration > 60` for three consecutive intervals.
 
-## 3. Frontend Experience
+## 3. API Gateway & Edge Overview
+
+**Purpose**: confirm authentication and routing health at the ingress layer.
+
+Panels:
+
+1. **Token issuance success rate** –
+   `sum by (status) (increase(legacycoin_http_requests_total{service="api-gateway", route="/auth/token"}[5m]))`.
+2. **Rate limiter rejections** – filter `legacycoin_http_request_errors_total`
+   where `route` matches the proxied prefix (for example `/api/v1/execution`)
+   and `status=429`.
+3. **Latency by downstream service** – use the `route` label to break out the
+   histogram query per proxied prefix.
+
+## 4. Frontend Experience
 
 **Purpose**: ensure the Flask dashboard remains healthy.
 
@@ -68,9 +106,10 @@ Panels:
 ## Implementation notes
 
 * All dashboards expect the Prometheus scrape config in
-  [`prometheus.yaml`](./prometheus.yaml).
-* Alert rules can be exported via Grafana as JSON and stored alongside this
-  file; use the metric queries above as templates.
+  [`prometheus.yaml`](./prometheus.yaml); the file already lists every service
+  endpoint.
+* Alert rules are provided in [`alerts.yaml`](./alerts.yaml) and can be loaded
+  directly into Alertmanager or Grafana's unified alerting.
 * Correlation IDs are attached to logs, traces and responses via the
   `X-Correlation-ID` header, enabling pivoting between Grafana, OpenSearch and
   tracing backends.

--- a/services/monitoring/alerts.yaml
+++ b/services/monitoring/alerts.yaml
@@ -1,0 +1,27 @@
+groups:
+  - name: legacycoin-service-alerts
+    rules:
+      - alert: HighMemoryUsage
+        expr: process_resident_memory_bytes{job=~"api-gateway|trading-engine|market-data|portfolio|strategy-engine|token-discovery|execution|frontend"} > 1.5e9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage detected on {{ $labels.job }}"
+          description: "Process RSS is {{ $value | humanize1024 }} which is above the 1.5 GiB threshold."
+      - alert: ElevatedErrorRate
+        expr: (sum by (service) (increase(legacycoin_http_request_errors_total[5m])) / clamp_min(sum by (service) (increase(legacycoin_http_requests_total[5m])), 1)) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High HTTP error rate for {{ $labels.service }}"
+          description: "The error rate exceeded 5% over the last 10 minutes."
+      - alert: HighRequestLatency
+        expr: histogram_quantile(0.95, sum by (service, le) (rate(legacycoin_http_request_duration_seconds_bucket[5m]))) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Increased latency for {{ $labels.service }}"
+          description: "95th percentile response time remained above 2 seconds for five minutes."

--- a/services/monitoring/prometheus.yaml
+++ b/services/monitoring/prometheus.yaml
@@ -2,16 +2,39 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - alerts.yaml
+
 scrape_configs:
+  - job_name: api-gateway
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api-gateway:8000']
   - job_name: trading-engine
     metrics_path: /metrics
     static_configs:
       - targets: ['trading-engine:8001']
+  - job_name: market-data
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['market-data:8002']
   - job_name: portfolio
     metrics_path: /metrics
     static_configs:
       - targets: ['portfolio:8003']
+  - job_name: strategy-engine
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['strategy-engine:8004']
+  - job_name: token-discovery
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['token-discovery:8005']
+  - job_name: execution
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['execution:8006']
   - job_name: frontend
     metrics_path: /metrics
     static_configs:
-      - targets: ['frontend:8000']
+      - targets: ['frontend:5000']


### PR DESCRIPTION
## Summary
- instrument the API gateway, execution, market-data, strategy-engine and token-discovery FastAPI apps with shared OpenTelemetry logging, tracing and Prometheus metrics
- expand the monitoring assets by adding Prometheus scrape targets, central alert rules and refreshed Grafana dashboard guidance
- expose alert configuration for error rate, latency and memory saturation alongside the existing dashboards documentation

## Testing
- pytest tests/test_observability.py *(fails: ModuleNotFoundError: No module named 'crypto_bot.regime.regime_classifier'; 'crypto_bot.regime' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68cab954a2fc833099be961dd1fa1aba