### PR TITLE
Refactor trading engine to use remote service clients

### DIFF
--- a/tests/services/test_trading_engine_interface.py
+++ b/tests/services/test_trading_engine_interface.py
@@ -171,6 +171,8 @@ async def test_trading_engine_run_cycle_executes_real_phases() -> None:
     assert services.strategy.requests, "strategy service should be invoked"
     assert services.execution.requests, "execution service should be invoked"
     assert services.execution.requests[0].symbol in {"BTC/USD", "ETH/USD"}
+    assert services.execution.requests[0].exchange is None
+    assert services.execution.requests[0].ws_client is None
     assert interface.context.analysis_results
     assert result.metadata["executed_trade_count"] == len(services.execution.requests)
 


### PR DESCRIPTION
## Summary
- replace the trading engine's local wrappers with HTTP-based clients for execution, risk, paper wallet, and position guard services
- update the trading interface lifecycle to prime and close the new clients while keeping state in Redis
- extend the trading engine functional test to assert that execution requests only rely on external service contracts

## Testing
- pytest tests/services/test_trading_engine_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68cad8ab4d408330a3fc003ab92df456