### PR TITLE
Add dedicated identity microservice and gateway integration

### DIFF
--- a/microservice_architecture.yaml
+++ b/microservice_architecture.yaml
@@ -59,6 +59,16 @@ services:
       - redis_cache
       - monitoring
 
+  # Identity Service - Authentication, authorization, user management
+  identity:
+    port: 8006
+    responsibilities:
+      - OAuth2/OIDC token issuance and introspection
+      - Credential rotation and validation
+      - SCIM user provisioning
+      - Multi-tenant secret management
+    dependencies: []
+
   # Strategy Engine - Strategy evaluation and routing
   strategy_engine:
     port: 8004

--- a/services/api_gateway/identity.py
+++ b/services/api_gateway/identity.py
@@ -1,118 +1,286 @@
+"""Async client for interacting with the identity microservice."""
+
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import List, Optional
+from urllib.parse import urljoin
 
-import jwt
-
-from services.portfolio.config import PortfolioConfig
-from services.portfolio.identity import (
-    ApiKeyRotationRequiredError,
-    ApiKeyValidationError,
-    InactiveAccountError,
-    InvalidCredentialsError,
-    PasswordExpiredError,
-    PortfolioIdentityService,
-    UserIdentity,
-)
+import httpx
 
 from .config import GatewaySettings
 
 LOGGER = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Exceptions shared with FastAPI handlers
+# ---------------------------------------------------------------------------
+
+
+class IdentityServiceError(RuntimeError):
+    """Base class for identity service errors."""
+
+
+class InvalidCredentialsError(IdentityServiceError):
+    """Raised when the identity service reports invalid credentials."""
+
+
+class InactiveAccountError(IdentityServiceError):
+    """Raised when an account is disabled."""
+
+
+class PasswordExpiredError(IdentityServiceError):
+    """Raised when a password rotation is required."""
+
+
+class ApiKeyValidationError(IdentityServiceError):
+    """Raised when an API key could not be validated."""
+
+
+class ApiKeyRotationRequiredError(ApiKeyValidationError):
+    """Raised when an API key is past its rotation deadline."""
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
 @dataclass(slots=True)
 class IssuedToken:
-    """Represents a JWT issued by the identity service."""
+    """Represents a JWT pair issued by the identity service."""
 
     access_token: str
+    refresh_token: Optional[str]
+    issued_at: datetime
     expires_at: datetime
     username: str
     roles: List[str]
     password_expires_at: Optional[datetime]
 
 
+@dataclass(slots=True)
+class UserIdentity:
+    """Simplified user metadata returned by the identity service."""
+
+    username: str
+    roles: List[str]
+    tenant: Optional[str]
+    password_rotated_at: Optional[datetime]
+    password_expires_at: Optional[datetime]
+    api_key_last_rotated_at: Optional[datetime]
+    api_key_expires_at: Optional[datetime]
+
+
+# ---------------------------------------------------------------------------
+# Identity client
+# ---------------------------------------------------------------------------
+
+
 class IdentityService:
-    """Bridge between the API gateway and the portfolio identity store."""
+    """HTTP client that proxies calls to the identity microservice."""
 
-    def __init__(self, settings: GatewaySettings) -> None:
+    def __init__(
+        self,
+        settings: GatewaySettings,
+        http_client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
         self.settings = settings
-        self.identity_store = PortfolioIdentityService(PortfolioConfig.from_env())
+        self._base_url = settings.identity_service_url.rstrip("/")
+        self._tenant = settings.identity_default_tenant
+        self._tenant_header = settings.identity_tenant_header
+        self._service_token = settings.identity_service_token
+        self._service_token_header = settings.identity_service_token_header
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.AsyncClient(timeout=settings.identity_request_timeout)
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
 
     # ------------------------------------------------------------------
-    # Token issuance
+    # Token issuance and refresh
     # ------------------------------------------------------------------
-    def issue_token(self, username: str, password: str) -> IssuedToken:
-        """Validate credentials and mint a JWT for downstream requests."""
-
-        identity = self.identity_store.authenticate_user(username, password)
-        issued_at = datetime.now(timezone.utc)
-        expires_at = issued_at + timedelta(seconds=max(60, self.settings.token_ttl_seconds))
-
-        roles = identity.roles or ["user"]
+    async def issue_token(self, username: str, password: str) -> IssuedToken:
         payload = {
-            "sub": identity.username,
-            "iat": int(issued_at.timestamp()),
-            "exp": int(expires_at.timestamp()),
-            "scopes": roles,
-            "roles": roles,
-            "iss": self.settings.token_issuer,
+            "grant_type": "password",
+            "username": username,
+            "password": password,
         }
-        if self.settings.jwt_audience:
-            payload["aud"] = self.settings.jwt_audience
+        response = await self._client.post(
+            self._url("/oauth/token"),
+            json=payload,
+            headers=self._headers(),
+        )
+        if response.status_code == 401:
+            raise InvalidCredentialsError("Invalid username or password")
+        if response.status_code == 403:
+            detail = response.json().get("detail") if response.headers.get("Content-Type", "").startswith("application/json") else response.text
+            if detail and "expired" in detail.lower():
+                raise PasswordExpiredError(detail)
+            raise InactiveAccountError(detail or "Account disabled")
+        response.raise_for_status()
+        data = response.json()
+        return self._parse_issued_token(data)
 
-        token = jwt.encode(
-            payload,
-            self.settings.jwt_secret,
-            algorithm=self.settings.jwt_algorithm,
+    async def refresh_token(self, refresh_token: str) -> IssuedToken:
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+        response = await self._client.post(
+            self._url("/oauth/token"),
+            json=payload,
+            headers=self._headers(),
         )
-
-        LOGGER.info("Issued access token for %s", identity.username)
-        password_expires_at = (
-            identity.password_expires_at.replace(tzinfo=timezone.utc)
-            if identity.password_expires_at
-            else None
-        )
-        return IssuedToken(
-            access_token=token,
-            expires_at=expires_at,
-            username=identity.username,
-            roles=roles,
-            password_expires_at=password_expires_at,
-        )
+        if response.status_code == 401:
+            raise InvalidCredentialsError("Refresh token invalid or expired")
+        response.raise_for_status()
+        data = response.json()
+        return self._parse_issued_token(data)
 
     # ------------------------------------------------------------------
     # Credential maintenance
     # ------------------------------------------------------------------
-    def rotate_password(
+    async def rotate_password(
         self,
         username: str,
         current_password: str,
         new_password: str,
     ) -> UserIdentity:
-        return self.identity_store.rotate_password(username, current_password, new_password)
+        payload = {
+            "username": username,
+            "current_password": current_password,
+            "new_password": new_password,
+        }
+        response = await self._client.post(
+            self._url("/credentials/password/rotate"),
+            json=payload,
+            headers=self._headers(),
+        )
+        if response.status_code == 401:
+            raise InvalidCredentialsError("Current password is incorrect")
+        if response.status_code == 403:
+            raise InactiveAccountError(response.json().get("detail", "Account disabled"))
+        response.raise_for_status()
+        return self._parse_user_identity(response.json())
 
-    def validate_api_key(self, api_key: str) -> UserIdentity:
-        return self.identity_store.validate_api_key(api_key)
+    async def validate_api_key(self, api_key: str) -> UserIdentity:
+        response = await self._client.post(
+            self._url("/credentials/api-key/validate"),
+            json={"api_key": api_key},
+            headers=self._headers(),
+        )
+        if response.status_code == 403:
+            raise ApiKeyRotationRequiredError(response.json().get("detail", "Rotation required"))
+        if response.status_code == 401:
+            raise ApiKeyValidationError(response.json().get("detail", "Invalid API key"))
+        response.raise_for_status()
+        return self._parse_user_identity(response.json())
 
-    def rotate_api_key(
+    async def rotate_api_key(
         self, username: str, *, new_api_key: Optional[str] = None
     ) -> tuple[str, UserIdentity]:
-        result = self.identity_store.rotate_api_key(username, new_api_key=new_api_key)
-        return result.api_key, result.user
+        payload = {"username": username}
+        if new_api_key:
+            payload["new_api_key"] = new_api_key
+        response = await self._client.post(
+            self._url("/credentials/api-key/rotate"),
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        data = response.json()
+        api_key = data.get("api_key") or ""
+        user = self._parse_user_identity(data)
+        return api_key, user
 
-    def list_users(self) -> List[UserIdentity]:
-        return self.identity_store.list_users()
+    async def list_users(self) -> List[UserIdentity]:
+        headers = self._headers(include_service_token=True)
+        response = await self._client.get(self._url("/scim/v2/Users"), headers=headers)
+        if response.status_code == 401:
+            raise IdentityServiceError("Service token required to list users")
+        response.raise_for_status()
+        payload = response.json()
+        resources = payload.get("Resources", [])
+        identities: List[UserIdentity] = []
+        for resource in resources:
+            identities.append(
+                UserIdentity(
+                    username=resource.get("userName", ""),
+                    roles=[role.get("value") for role in resource.get("roles", []) if role.get("value")],
+                    tenant=self._tenant,
+                    password_rotated_at=None,
+                    password_expires_at=None,
+                    api_key_last_rotated_at=None,
+                    api_key_expires_at=None,
+                )
+            )
+        return identities
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _headers(self, *, include_service_token: bool = False) -> dict:
+        headers = {"Content-Type": "application/json"}
+        if self._tenant:
+            headers[self._tenant_header] = self._tenant
+        if self._service_token and (include_service_token or self._service_token_header):
+            headers[self._service_token_header] = self._service_token
+        return headers
+
+    def _url(self, path: str) -> str:
+        return urljoin(f"{self._base_url}/", path.lstrip("/"))
+
+    def _parse_issued_token(self, payload: dict) -> IssuedToken:
+        issued_at = self._parse_datetime(payload.get("issued_at"))
+        expires_at = self._parse_datetime(payload.get("expires_at"))
+        password_expires_at = self._parse_datetime(payload.get("password_expires_at"))
+        roles = payload.get("roles") or []
+        if isinstance(roles, str):
+            roles = [role for role in roles.split() if role]
+        return IssuedToken(
+            access_token=payload.get("access_token", ""),
+            refresh_token=payload.get("refresh_token"),
+            issued_at=issued_at,
+            expires_at=expires_at,
+            username=payload.get("username", ""),
+            roles=list(roles),
+            password_expires_at=password_expires_at,
+        )
+
+    def _parse_user_identity(self, payload: dict) -> UserIdentity:
+        return UserIdentity(
+            username=payload.get("username", ""),
+            roles=[str(role) for role in payload.get("roles", [])],
+            tenant=payload.get("tenant") or self._tenant,
+            password_rotated_at=self._parse_datetime(payload.get("password_rotated_at")),
+            password_expires_at=self._parse_datetime(payload.get("password_expires_at")),
+            api_key_last_rotated_at=self._parse_datetime(payload.get("api_key_last_rotated_at")),
+            api_key_expires_at=self._parse_datetime(payload.get("api_key_expires_at")),
+        )
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            LOGGER.debug("Failed to parse datetime value '%s'", value)
+            return None
 
 
 __all__ = [
     "ApiKeyRotationRequiredError",
     "ApiKeyValidationError",
     "IdentityService",
+    "IssuedToken",
     "InactiveAccountError",
     "InvalidCredentialsError",
-    "IssuedToken",
     "PasswordExpiredError",
+    "UserIdentity",
 ]

--- a/services/identity/README.md
+++ b/services/identity/README.md
@@ -1,0 +1,151 @@
+# Identity Service
+
+The identity service provides authentication and authorization for LegacyCoinTrader. It is
+implemented as a standalone FastAPI microservice with optional gRPC bindings and manages
+multi-tenant users, roles, and credentials. The service issues OAuth2/OIDC compatible
+JWTs, stores refresh tokens, exposes SCIM provisioning endpoints, and integrates with
+external secret managers (Hashicorp Vault or AWS Secrets Manager) for tenant specific
+signing keys and API secrets.
+
+## Features
+
+* OAuth2/OIDC token issuance (`password` and `refresh_token` grants), refresh, and
+  standards compliant token introspection.
+* Multi-tenant aware SQLAlchemy models for tenants, users, roles, credentials, and
+  refresh tokens. Password and API-key rotation metadata is tracked on every
+  credential record.
+* MFA hooks with pluggable providers (TOTP included by default).
+* SCIM `Users` API for provisioning and de-provisioning identities.
+* REST and gRPC surfaces for token and credential operations.
+* Service-to-service authentication helpers so other microservices can validate
+  identity issued tokens via JWKS or remote introspection.
+
+## REST API
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/oauth/token` | `POST` | Issue an access/refresh token pair (`password` or `refresh_token` grant). |
+| `/oauth/introspect` | `POST` | RFC 7662 compatible token introspection. Requires service token. |
+| `/credentials/password/rotate` | `POST` | Rotate a user password after validating the current secret. |
+| `/credentials/api-key/rotate` | `POST` | Rotate an API key (optionally supply a pre-generated key). |
+| `/credentials/api-key/validate` | `POST` | Validate an API key and return the owning identity metadata. |
+| `/scim/v2/Users` | `GET/POST` | SCIM user listing and provisioning (requires service token). |
+| `/scim/v2/Users/{id}` | `GET/PUT/DELETE` | Retrieve, replace, or delete a SCIM user. |
+| `/.well-known/openid-configuration` | `GET` | Standard discovery metadata. |
+| `/.well-known/jwks.json` | `GET` | JWKS containing tenant public keys for JWT verification. |
+
+### gRPC Service
+
+The gRPC endpoint (service name `identity.v1.Identity`) exposes the following unary
+operations. All requests and responses use `google.protobuf.Struct` payloads to avoid
+requiring generated client code.
+
+* `IssueToken`
+* `RefreshToken`
+* `IntrospectToken`
+* `RotatePassword`
+* `RotateApiKey`
+* `ValidateApiKey`
+
+See `services/identity/api/grpc.py` for usage.
+
+## Database & Migrations
+
+Alembic migrations live in `services/identity/migrations`. Apply them with:
+
+```bash
+alembic -c services/identity/alembic.ini upgrade head
+```
+
+(or execute programmatically using `services.identity.database` helpers).
+The initial migration (`0001_identity`) creates tables for tenants, roles, users,
+role assignments, credentials, and refresh tokens.
+
+## Configuration
+
+Configuration is driven by the following environment variables (defaults shown):
+
+| Variable | Description |
+| --- | --- |
+| `IDENTITY_DATABASE_URL` | SQLAlchemy database URL (`sqlite:///./identity.db`). |
+| `IDENTITY_ACCESS_TOKEN_TTL_SECONDS` | Access token lifetime (seconds). |
+| `IDENTITY_REFRESH_TOKEN_TTL_SECONDS` | Refresh token lifetime (seconds). |
+| `IDENTITY_TOKEN_ALGORITHM` | JWT signing algorithm (default `RS256`). |
+| `IDENTITY_DEFAULT_ISSUER` | Base issuer URI used for new tenants. |
+| `IDENTITY_DEFAULT_TENANT` | Tenant slug to use when no header is provided (`primary`). |
+| `IDENTITY_SERVICE_TOKEN_HEADER` | Header name for service tokens (`x-service-token`). |
+| `IDENTITY_INTERNAL_SERVICE_TOKEN` | Optional shared secret required for privileged endpoints. |
+| `IDENTITY_TENANT_HEADER_CANDIDATES` | Comma separated tenant headers to inspect (`X-Tenant-ID,X-Tenant,X-Realm`). |
+| `IDENTITY_ALLOW_DEVELOPMENT_FALLBACK_KEYS` | Generate ephemeral signing keys when secrets are missing (defaults to `true`). |
+| `IDENTITY_JWKS_CACHE_SECONDS` | Cache lifetime for JWKS responses (default `300`). |
+
+### Secret Storage
+
+Each tenant stores a `secret_reference` describing where its signing material lives. The
+identity service resolves the key using `services.common.secrets.SecretManager`, which
+supports environment variables, Hashicorp Vault, and AWS Secrets Manager.
+
+* **Vault** – set `SECRETS_PROVIDER=vault` and configure `VAULT_ADDR`, `VAULT_TOKEN`, and
+  `VAULT_SECRET_PATH`. Within Vault, place a JSON document at the tenant specific path,
+  e.g. `tenants/<tenant>/identity` with:
+
+  ```json
+  {
+    "algorithm": "RS256",
+    "private_key": "-----BEGIN PRIVATE KEY-----...",
+    "public_key": "-----BEGIN PUBLIC KEY-----..."
+  }
+  ```
+
+* **AWS Secrets Manager** – set `SECRETS_PROVIDER=aws` with `AWS_SECRET_NAME` and
+  `AWS_REGION`. The secret payload should contain the same JSON structure.
+
+If a symmetric algorithm (e.g. `HS256`) is required, provide a `shared_secret` value in
+place of the RSA keys. JWKS responses omit symmetric keys by design.
+
+## Service-to-Service Token Validation
+
+Consumers can validate tokens without hard-coding shared secrets by using the helper
+classes in `services.identity.auth`.
+
+```python
+from services.identity.auth import IdentityTokenValidator
+
+validator = IdentityTokenValidator(
+    "http://identity:8006/.well-known/jwks.json",
+    issuer="https://identity.legacycointrader.local/primary",
+)
+claims = validator.validate(access_token)
+print(claims.subject, claims.roles)
+```
+
+For network-based validation, use the introspection client:
+
+```python
+from services.identity.auth import IdentityIntrospectionClient
+
+with IdentityIntrospectionClient(
+    "http://identity:8006",
+    service_token="<gateway service token>",
+    default_tenant="primary",
+) as client:
+    introspection = client.introspect(access_token)
+    assert introspection["active"]
+```
+
+## API Gateway Integration
+
+The API gateway loads identity settings via new environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `IDENTITY_SERVICE_URL` | Base URL to the identity service (default `http://identity:8006`). |
+| `IDENTITY_JWKS_URL` | JWKS endpoint (defaults to `<IDENTITY_SERVICE_URL>/.well-known/jwks.json`). |
+| `IDENTITY_DEFAULT_TENANT` | Tenant slug forwarded on gateway issued requests. |
+| `IDENTITY_SERVICE_TOKEN` | Service token presented to the identity service. |
+| `IDENTITY_TENANT_HEADER` | Header used to convey the tenant (default `X-Tenant-ID`). |
+| `IDENTITY_REQUEST_TIMEOUT` | HTTP timeout for identity requests (default `10` seconds). |
+| `IDENTITY_EXPECTED_ISSUER` / `IDENTITY_EXPECTED_AUDIENCE` | Optional OIDC issuer/audience checks for JWT validation. |
+
+The gateway now delegates all authentication and credential management to the identity
+service and validates JWTs using JWKS metadata from the `/well-known/jwks.json` endpoint.

--- a/services/identity/__init__.py
+++ b/services/identity/__init__.py
@@ -1,0 +1,10 @@
+"""Identity service package for LegacyCoinTrader."""
+
+from .config import IdentitySettings, load_identity_settings
+from .service import IdentityService
+
+__all__ = [
+    "IdentityService",
+    "IdentitySettings",
+    "load_identity_settings",
+]

--- a/services/identity/api/grpc.py
+++ b/services/identity/api/grpc.py
@@ -1,0 +1,223 @@
+"""Minimal gRPC surface for the identity service."""
+
+from __future__ import annotations
+
+from concurrent import futures
+from datetime import datetime
+from typing import Dict, Optional
+
+import grpc
+from google.protobuf import struct_pb2
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+from ..service import (
+    ApiKeyRotationRequiredError,
+    ApiKeyValidationError,
+    IdentityService,
+    InactiveAccountError,
+    InvalidCredentialsError,
+    PasswordExpiredError,
+    RefreshTokenError,
+)
+
+SERVICE_NAME = "identity.v1.Identity"
+
+
+def _datetime_to_iso(value: Optional[datetime]) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+class IdentityGrpcApi:
+    """Implementation of gRPC handlers forwarding to :class:`IdentityService`."""
+
+    def __init__(self, identity_service: IdentityService) -> None:
+        self.identity_service = identity_service
+
+    # ------------------------------------------------------------------
+    # RPC method implementations
+    # ------------------------------------------------------------------
+    def issue_token(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        try:
+            token_pair = self.identity_service.issue_token(
+                payload.get("tenant"),
+                payload.get("username", ""),
+                payload.get("password", ""),
+                requested_scopes=payload.get("scope"),
+                mfa_code=payload.get("mfa_code"),
+            )
+        except (InvalidCredentialsError, PasswordExpiredError) as exc:
+            context.abort(grpc.StatusCode.UNAUTHENTICATED, str(exc))
+        except InactiveAccountError as exc:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, str(exc))
+        response = {
+            "access_token": token_pair.access_token,
+            "refresh_token": token_pair.refresh_token,
+            "expires_in": token_pair.expires_in,
+            "expires_at": token_pair.expires_at.isoformat(),
+            "issued_at": token_pair.issued_at.isoformat(),
+            "scope": token_pair.scope,
+            "roles": token_pair.roles,
+            "username": token_pair.username,
+            "tenant": token_pair.tenant,
+            "password_expires_at": _datetime_to_iso(token_pair.password_expires_at),
+        }
+        return ParseDict(response, struct_pb2.Struct())
+
+    def refresh_token(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        scope_value = payload.get("scope")
+        if isinstance(scope_value, str):
+            scope_value = [part for part in scope_value.split() if part]
+        elif isinstance(scope_value, list):
+            scope_value = [str(part) for part in scope_value]
+        else:
+            scope_value = None
+        try:
+            token_pair = self.identity_service.refresh_token(
+                payload.get("tenant"),
+                payload.get("refresh_token", ""),
+                scope=scope_value,
+            )
+        except RefreshTokenError as exc:
+            context.abort(grpc.StatusCode.UNAUTHENTICATED, str(exc))
+        response = {
+            "access_token": token_pair.access_token,
+            "refresh_token": token_pair.refresh_token,
+            "expires_in": token_pair.expires_in,
+            "expires_at": token_pair.expires_at.isoformat(),
+            "issued_at": token_pair.issued_at.isoformat(),
+            "scope": token_pair.scope,
+            "roles": token_pair.roles,
+            "username": token_pair.username,
+            "tenant": token_pair.tenant,
+            "password_expires_at": _datetime_to_iso(token_pair.password_expires_at),
+        }
+        return ParseDict(response, struct_pb2.Struct())
+
+    def introspect_token(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        response = self.identity_service.introspect_token(
+            payload.get("tenant"), payload.get("token", "")
+        )
+        result = {
+            "active": response.active,
+            "username": response.username,
+            "subject": response.subject,
+            "tenant": response.tenant,
+            "scope": response.scope,
+            "roles": response.roles,
+            "issued_at": _datetime_to_iso(response.issued_at),
+            "expires_at": _datetime_to_iso(response.expires_at),
+            "token_type": response.token_type,
+            "client_id": response.client_id,
+            "claims": response.claims,
+        }
+        return ParseDict(result, struct_pb2.Struct())
+
+    def rotate_password(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        try:
+            user = self.identity_service.rotate_password(
+                payload.get("tenant"),
+                payload.get("username", ""),
+                payload.get("current_password", ""),
+                payload.get("new_password", ""),
+            )
+        except InvalidCredentialsError as exc:
+            context.abort(grpc.StatusCode.UNAUTHENTICATED, str(exc))
+        except InactiveAccountError as exc:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, str(exc))
+        result = _identity_user_payload(user)
+        return ParseDict(result, struct_pb2.Struct())
+
+    def rotate_api_key(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        try:
+            api_key, user = self.identity_service.rotate_api_key(
+                payload.get("tenant"),
+                payload.get("username", ""),
+                new_api_key=payload.get("new_api_key"),
+            )
+        except InactiveAccountError as exc:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, str(exc))
+        result = _identity_user_payload(user)
+        result["api_key"] = api_key
+        return ParseDict(result, struct_pb2.Struct())
+
+    def validate_api_key(self, request: struct_pb2.Struct, context) -> struct_pb2.Struct:
+        payload = MessageToDict(request, preserving_proto_field_name=True)
+        try:
+            user = self.identity_service.validate_api_key(
+                payload.get("tenant"), payload.get("api_key", "")
+            )
+        except ApiKeyRotationRequiredError as exc:
+            context.abort(grpc.StatusCode.PERMISSION_DENIED, str(exc))
+        except ApiKeyValidationError as exc:
+            context.abort(grpc.StatusCode.UNAUTHENTICATED, str(exc))
+        result = _identity_user_payload(user)
+        return ParseDict(result, struct_pb2.Struct())
+
+    # ------------------------------------------------------------------
+    # Handler registration
+    # ------------------------------------------------------------------
+    def as_generic_handler(self) -> grpc.GenericRpcHandler:
+        return grpc.method_handlers_generic_handler(
+            SERVICE_NAME,
+            {
+                "IssueToken": grpc.unary_unary_rpc_method_handler(
+                    self.issue_token,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+                "RefreshToken": grpc.unary_unary_rpc_method_handler(
+                    self.refresh_token,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+                "IntrospectToken": grpc.unary_unary_rpc_method_handler(
+                    self.introspect_token,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+                "RotatePassword": grpc.unary_unary_rpc_method_handler(
+                    self.rotate_password,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+                "RotateApiKey": grpc.unary_unary_rpc_method_handler(
+                    self.rotate_api_key,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+                "ValidateApiKey": grpc.unary_unary_rpc_method_handler(
+                    self.validate_api_key,
+                    request_deserializer=struct_pb2.Struct.FromString,
+                    response_serializer=struct_pb2.Struct.SerializeToString,
+                ),
+            },
+        )
+
+
+def _identity_user_payload(user) -> Dict[str, object]:
+    return {
+        "username": user.username,
+        "roles": list(user.roles),
+        "tenant": user.tenant,
+        "password_rotated_at": _datetime_to_iso(user.password_rotated_at),
+        "password_expires_at": _datetime_to_iso(user.password_expires_at),
+        "api_key_last_rotated_at": _datetime_to_iso(user.api_key_last_rotated_at),
+        "api_key_expires_at": _datetime_to_iso(user.api_key_expires_at),
+    }
+
+
+def create_server(identity_service: IdentityService, *, max_workers: int = 10) -> grpc.Server:
+    """Return a configured gRPC server instance."""
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
+    handler = IdentityGrpcApi(identity_service).as_generic_handler()
+    server.add_generic_rpc_handlers((handler,))
+    return server
+
+
+__all__ = ["SERVICE_NAME", "IdentityGrpcApi", "create_server"]

--- a/services/identity/api/rest.py
+++ b/services/identity/api/rest.py
@@ -1,0 +1,395 @@
+"""FastAPI application exposing the identity service."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Annotated, List, Optional
+
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from ..config import IdentitySettings, load_identity_settings
+from ..database import get_session
+from ..models import TenantModel
+from ..schemas import IntrospectionResponse
+from ..service import (
+    ApiKeyRotationRequiredError,
+    ApiKeyValidationError,
+    IdentityService,
+    IdentityUser,
+    InactiveAccountError,
+    InvalidCredentialsError,
+    PasswordExpiredError,
+    RefreshTokenError,
+    ScimOperationError,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Dependency helpers
+# ---------------------------------------------------------------------------
+
+
+@lru_cache
+def get_settings() -> IdentitySettings:
+    return load_identity_settings()
+
+
+@lru_cache
+def get_identity_service() -> IdentityService:
+    settings = get_settings()
+    return IdentityService(settings)
+
+
+def resolve_tenant(
+    request: Request,
+    settings: Annotated[IdentitySettings, Depends(get_settings)],
+    tenant_header: Optional[str] = Header(default=None, alias="X-Tenant"),
+) -> Optional[str]:
+    candidates = list(settings.tenant_header_candidates)
+    if tenant_header:
+        return tenant_header
+    for header in candidates:
+        value = request.headers.get(header)
+        if value:
+            return value
+    return settings.default_tenant_slug
+
+
+def require_service_token(
+    request: Request,
+    settings: Annotated[IdentitySettings, Depends(get_settings)],
+) -> None:
+    token = request.headers.get(settings.service_token_header)
+    if settings.internal_service_token and token != settings.internal_service_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid service token")
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class OAuthTokenRequest(BaseModel):
+    grant_type: str = Field(..., alias="grant_type")
+    username: Optional[str] = None
+    password: Optional[str] = None
+    refresh_token: Optional[str] = None
+    scope: Optional[str] = None
+    mfa_code: Optional[str] = Field(default=None, alias="mfa_code")
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "Bearer"
+    expires_in: int
+    expires_at: str
+    issued_at: str
+    scope: List[str]
+    roles: List[str]
+    username: str
+    tenant: str
+    password_expires_at: Optional[str] = None
+
+
+class PasswordRotateRequest(BaseModel):
+    username: str
+    current_password: str
+    new_password: str
+
+
+class ApiKeyRotateRequest(BaseModel):
+    username: str
+    new_api_key: Optional[str] = None
+
+
+class ApiKeyValidateRequest(BaseModel):
+    api_key: str
+
+
+class IntrospectionRequest(BaseModel):
+    token: str
+
+
+# ---------------------------------------------------------------------------
+# Helper conversion functions
+# ---------------------------------------------------------------------------
+
+
+def _token_pair_to_response(token_pair) -> TokenResponse:
+    return TokenResponse(
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        expires_in=token_pair.expires_in,
+        expires_at=token_pair.expires_at.isoformat(),
+        issued_at=token_pair.issued_at.isoformat(),
+        scope=list(token_pair.scope),
+        roles=list(token_pair.roles),
+        username=token_pair.username,
+        tenant=token_pair.tenant,
+        password_expires_at=token_pair.password_expires_at.isoformat()
+        if token_pair.password_expires_at
+        else None,
+    )
+
+
+def _identity_user_to_payload(user: IdentityUser) -> dict:
+    return {
+        "username": user.username,
+        "roles": user.roles,
+        "password_rotated_at": user.password_rotated_at.isoformat() if user.password_rotated_at else None,
+        "password_expires_at": user.password_expires_at.isoformat() if user.password_expires_at else None,
+        "api_key_last_rotated_at": user.api_key_last_rotated_at.isoformat()
+        if user.api_key_last_rotated_at
+        else None,
+        "api_key_expires_at": user.api_key_expires_at.isoformat() if user.api_key_expires_at else None,
+        "tenant": user.tenant,
+    }
+
+
+# ---------------------------------------------------------------------------
+# OAuth endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/oauth/token", response_model=TokenResponse)
+def issue_token(
+    payload: OAuthTokenRequest,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+):
+    try:
+        if payload.grant_type == "password":
+            token_pair = service.issue_token(
+                tenant,
+                payload.username or "",
+                payload.password or "",
+                requested_scopes=payload.scope,
+                mfa_code=payload.mfa_code,
+            )
+        elif payload.grant_type == "refresh_token":
+            if not payload.refresh_token:
+                raise HTTPException(status_code=400, detail="refresh_token is required")
+            token_pair = service.refresh_token(
+                tenant,
+                payload.refresh_token,
+                scope=(payload.scope.split() if payload.scope else None),
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Unsupported grant_type",
+            )
+    except InvalidCredentialsError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    except InactiveAccountError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except PasswordExpiredError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except RefreshTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    return _token_pair_to_response(token_pair)
+
+
+@router.post("/oauth/introspect", response_model=IntrospectionResponse)
+def introspect_token(
+    payload: IntrospectionRequest,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    return service.introspect_token(tenant, payload.token)
+
+
+# ---------------------------------------------------------------------------
+# Credential management endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/credentials/password/rotate")
+def rotate_password(
+    payload: PasswordRotateRequest,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+):
+    try:
+        user = service.rotate_password(
+            tenant,
+            payload.username,
+            payload.current_password,
+            payload.new_password,
+        )
+    except InvalidCredentialsError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    except InactiveAccountError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return _identity_user_to_payload(user)
+
+
+@router.post("/credentials/api-key/rotate")
+def rotate_api_key(
+    payload: ApiKeyRotateRequest,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+):
+    api_key, user = service.rotate_api_key(
+        tenant,
+        payload.username,
+        new_api_key=payload.new_api_key,
+    )
+    response = _identity_user_to_payload(user)
+    response["api_key"] = api_key
+    return response
+
+
+@router.post("/credentials/api-key/validate")
+def validate_api_key(
+    payload: ApiKeyValidateRequest,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+):
+    try:
+        user = service.validate_api_key(tenant, payload.api_key)
+    except ApiKeyRotationRequiredError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ApiKeyValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    return _identity_user_to_payload(user)
+
+
+# ---------------------------------------------------------------------------
+# SCIM endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/scim/v2/Users")
+def scim_list_users(
+    request: Request,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    base_url = str(request.base_url).rstrip("/")
+    users = service.scim_list_users(tenant, base_url)
+    return {
+        "Resources": [user.model_dump(mode="json") for user in users],
+        "totalResults": len(users),
+        "itemsPerPage": len(users),
+        "startIndex": 1,
+    }
+
+
+@router.get("/scim/v2/Users/{user_id}")
+def scim_get_user(
+    user_id: int,
+    request: Request,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    base_url = str(request.base_url).rstrip("/")
+    try:
+        user = service.scim_get_user(tenant, user_id, base_url)
+    except ScimOperationError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return JSONResponse(user.model_dump(mode="json"))
+
+
+@router.post("/scim/v2/Users", status_code=status.HTTP_201_CREATED)
+def scim_create_user(
+    payload: dict,
+    request: Request,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    base_url = str(request.base_url).rstrip("/")
+    try:
+        user = service.scim_create_user(tenant, payload, base_url)
+    except ScimOperationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return JSONResponse(user.model_dump(mode="json"), status_code=status.HTTP_201_CREATED)
+
+
+@router.put("/scim/v2/Users/{user_id}")
+def scim_replace_user(
+    user_id: int,
+    payload: dict,
+    request: Request,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    base_url = str(request.base_url).rstrip("/")
+    try:
+        user = service.scim_replace_user(tenant, user_id, payload, base_url)
+    except ScimOperationError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return JSONResponse(user.model_dump(mode="json"))
+
+
+@router.delete("/scim/v2/Users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def scim_delete_user(
+    user_id: int,
+    tenant: Annotated[Optional[str], Depends(resolve_tenant)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+    _: Annotated[None, Depends(require_service_token)] = None,
+):
+    service.scim_delete_user(tenant, user_id)
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content={})
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+@router.get("/.well-known/openid-configuration")
+def openid_configuration(
+    request: Request,
+    settings: Annotated[IdentitySettings, Depends(get_settings)],
+    service: Annotated[IdentityService, Depends(get_identity_service)],
+):
+    base = str(request.base_url).rstrip("/")
+    issuer = settings.default_issuer
+    jwks_uri = f"{base}/.well-known/jwks.json"
+    token_endpoint = f"{base}/oauth/token"
+    introspection_endpoint = f"{base}/oauth/introspect"
+    return {
+        "issuer": issuer,
+        "jwks_uri": jwks_uri,
+        "token_endpoint": token_endpoint,
+        "introspection_endpoint": introspection_endpoint,
+        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        "response_types_supported": ["token"],
+        "grant_types_supported": ["password", "refresh_token"],
+    }
+
+
+@router.get("/.well-known/jwks.json")
+def jwks(service: Annotated[IdentityService, Depends(get_identity_service)]):
+    with get_session(service.settings) as session:
+        tenants = session.scalars(select(TenantModel)).all()
+        for tenant in tenants:
+            service.token_signer.get_signing_key(tenant)
+    keys = service.token_signer.build_jwks()
+    return JSONResponse(keys)
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="LegacyCoinTrader Identity Service", version="1.0.0")
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/services/identity/auth.py
+++ b/services/identity/auth.py
@@ -1,0 +1,132 @@
+"""Helper utilities for validating identity-issued tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import httpx
+import jwt
+from jwt import InvalidTokenError, PyJWKClient
+
+DEFAULT_TENANT_HEADER = "X-Tenant-ID"
+
+
+@dataclass(slots=True)
+class TokenClaims:
+    """Normalised view over JWT/OIDC claims."""
+
+    subject: str
+    tenant: Optional[str]
+    roles: List[str]
+    scopes: List[str]
+    expires_at: datetime
+    issued_at: datetime
+    raw_claims: Dict[str, object]
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at < datetime.now(timezone.utc)
+
+
+class IdentityTokenValidator:
+    """Validate JWT tokens issued by the identity service using JWKS."""
+
+    def __init__(
+        self,
+        jwks_url: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str] = None,
+        cache_ttl_seconds: int = 300,
+    ) -> None:
+        self.jwks_client = PyJWKClient(jwks_url, cache_keys=True, lifespan=cache_ttl_seconds)
+        self.issuer = issuer
+        self.audience = audience
+
+    def validate(self, token: str) -> TokenClaims:
+        try:
+            signing_key = self.jwks_client.get_signing_key_from_jwt(token)
+            payload = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=[signing_key.algorithm],
+                audience=self.audience,
+                issuer=self.issuer,
+                options={
+                    "verify_aud": self.audience is not None,
+                    "verify_iss": self.issuer is not None,
+                },
+            )
+        except InvalidTokenError as exc:
+            raise InvalidTokenError(f"Identity token validation failed: {exc}") from exc
+        return self._claims_from_payload(payload)
+
+    def _claims_from_payload(self, payload: Dict[str, object]) -> TokenClaims:
+        scopes_raw = payload.get("scope") or payload.get("scopes") or []
+        if isinstance(scopes_raw, str):
+            scopes = [scope for scope in scopes_raw.split() if scope]
+        else:
+            scopes = [str(scope) for scope in scopes_raw]
+        roles_raw = payload.get("roles") or []
+        if isinstance(roles_raw, str):
+            roles = [role for role in roles_raw.split() if role]
+        else:
+            roles = [str(role) for role in roles_raw]
+        issued_at = datetime.fromtimestamp(int(payload.get("iat", 0)), tz=timezone.utc)
+        expires_at = datetime.fromtimestamp(int(payload.get("exp", 0)), tz=timezone.utc)
+        return TokenClaims(
+            subject=str(payload.get("sub")),
+            tenant=str(payload.get("tenant") or payload.get("tid")) if payload.get("tenant") or payload.get("tid") else None,
+            roles=roles,
+            scopes=scopes,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            raw_claims=dict(payload),
+        )
+
+
+class IdentityIntrospectionClient:
+    """Client for the identity service token introspection endpoint."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        service_token: str,
+        tenant_header: str = DEFAULT_TENANT_HEADER,
+        default_tenant: Optional[str] = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.service_token = service_token
+        self.tenant_header = tenant_header
+        self.default_tenant = default_tenant
+        self._client = httpx.Client(base_url=self.base_url, timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def introspect(self, token: str, *, tenant: Optional[str] = None) -> Dict[str, object]:
+        headers = {"Content-Type": "application/json", DEFAULT_TENANT_HEADER: tenant or self.default_tenant or ""}
+        if self.tenant_header:
+            headers[self.tenant_header] = tenant or self.default_tenant or ""
+        headers["x-service-token"] = self.service_token
+        response = self._client.post("/oauth/introspect", json={"token": token}, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    def __enter__(self) -> "IdentityIntrospectionClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = [
+    "DEFAULT_TENANT_HEADER",
+    "IdentityIntrospectionClient",
+    "IdentityTokenValidator",
+    "TokenClaims",
+]

--- a/services/identity/config.py
+++ b/services/identity/config.py
@@ -1,0 +1,81 @@
+"""Configuration helpers for the identity service."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List, Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class IdentitySettings(BaseSettings):
+    """Runtime configuration for the identity microservice."""
+
+    database_url: str = Field(
+        default="sqlite:///./identity.db",
+        description="SQLAlchemy database URL",
+    )
+    access_token_ttl_seconds: int = Field(
+        default=3600,
+        description="Default lifetime for access tokens in seconds.",
+    )
+    refresh_token_ttl_seconds: int = Field(
+        default=86_400,
+        description="Lifetime for refresh tokens in seconds.",
+    )
+    token_algorithm: str = Field(
+        default="RS256",
+        description="JWT signing algorithm used for issued tokens.",
+    )
+    default_issuer: str = Field(
+        default="https://identity.legacycointrader.local",
+        description="Issuer identifier used for newly created tenants.",
+    )
+    default_tenant_slug: str = Field(
+        default="primary",
+        description="Slug used when a request omits explicit tenant information.",
+    )
+    service_token_header: str = Field(
+        default="x-service-token",
+        description="Header used to authenticate service-to-service requests.",
+    )
+    internal_service_token: Optional[str] = Field(
+        default=None,
+        description="Shared secret that downstream services must present when invoking privileged endpoints.",
+    )
+    allow_development_fallback_keys: bool = Field(
+        default=True,
+        description="Generate ephemeral signing keys when external secret stores are unavailable (development only).",
+    )
+    jwks_cache_seconds: int = Field(
+        default=300,
+        description="How long JWKS responses should be cached by clients.",
+    )
+    tenant_header_candidates: List[str] = Field(
+        default_factory=lambda: ["x-tenant-id", "x-tenant", "x-realm"],
+        description="Headers inspected to determine the active tenant for a request.",
+    )
+    scim_enabled: bool = Field(
+        default=True,
+        description="Whether the SCIM provisioning API should be exposed.",
+    )
+    model_config = SettingsConfigDict(
+        env_prefix="IDENTITY_",
+        env_file=".env",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+@lru_cache
+def load_identity_settings() -> IdentitySettings:
+    """Return cached identity settings."""
+
+    return IdentitySettings()
+
+
+__all__ = [
+    "IdentitySettings",
+    "load_identity_settings",
+]

--- a/services/identity/database.py
+++ b/services/identity/database.py
@@ -1,0 +1,65 @@
+"""Database helpers for the identity service."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from .config import IdentitySettings, load_identity_settings
+
+
+Base = declarative_base()
+
+_engine = None
+_SessionLocal = None
+
+
+def get_engine(settings: IdentitySettings | None = None):
+    """Return a singleton SQLAlchemy engine."""
+
+    global _engine
+    settings = settings or load_identity_settings()
+    if _engine is None:
+        _engine = create_engine(settings.database_url, echo=False, future=True)
+    return _engine
+
+
+def get_session_factory(settings: IdentitySettings | None = None):
+    """Return a cached SQLAlchemy session factory."""
+
+    global _SessionLocal
+    settings = settings or load_identity_settings()
+    if _SessionLocal is None:
+        _SessionLocal = sessionmaker(
+            bind=get_engine(settings),
+            expire_on_commit=False,
+            class_=Session,
+        )
+    return _SessionLocal
+
+
+@contextmanager
+def get_session(settings: IdentitySettings | None = None) -> Iterator[Session]:
+    """Provide a transactional scope for identity operations."""
+
+    session_factory = get_session_factory(settings)
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+__all__ = [
+    "Base",
+    "get_engine",
+    "get_session",
+    "get_session_factory",
+]

--- a/services/identity/mfa.py
+++ b/services/identity/mfa.py
@@ -1,0 +1,96 @@
+"""Pluggable multi-factor authentication helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import struct
+import time
+from typing import Protocol
+
+from .models import UserModel
+
+
+class MfaChallengeError(RuntimeError):
+    """Raised when MFA validation fails."""
+
+
+class MfaProvider(Protocol):
+    """Interface that custom MFA providers must implement."""
+
+    def is_required(self, user: UserModel) -> bool:  # pragma: no cover - protocol definition
+        ...
+
+    def verify(self, user: UserModel, code: str) -> bool:  # pragma: no cover - protocol definition
+        ...
+
+    def challenge(self, user: UserModel) -> None:  # pragma: no cover - protocol definition
+        ...
+
+
+class NullMfaProvider:
+    """MFA provider used when MFA is disabled."""
+
+    def is_required(self, user: UserModel) -> bool:
+        return False
+
+    def verify(self, user: UserModel, code: str) -> bool:
+        del user, code
+        return True
+
+    def challenge(self, user: UserModel) -> None:
+        del user
+
+
+class TotpMfaProvider:
+    """Simple TOTP-based MFA provider compatible with most authenticators."""
+
+    def __init__(self, *, digits: int = 6, interval: int = 30, window: int = 1) -> None:
+        self.digits = digits
+        self.interval = interval
+        self.window = window
+
+    def is_required(self, user: UserModel) -> bool:
+        return bool(user.mfa_enforced and user.mfa_secret)
+
+    def verify(self, user: UserModel, code: str) -> bool:
+        if not self.is_required(user):
+            return True
+        if not code:
+            return False
+        expected = self._totp_codes(user.mfa_secret or "")
+        return code in expected
+
+    def challenge(self, user: UserModel) -> None:
+        # A real implementation could send push notifications or email. The
+        # hook is intentionally left blank but documented.
+        del user
+
+    def _totp_codes(self, secret: str) -> set[str]:
+        key = _decode_base32(secret)
+        codes: set[str] = set()
+        timestamp = int(time.time() // self.interval)
+        for offset in range(-self.window, self.window + 1):
+            counter = timestamp + offset
+            counter_bytes = struct.pack(">Q", counter)
+            digest = hmac.new(key, counter_bytes, hashlib.sha1).digest()
+            pos = digest[-1] & 0x0F
+            truncated = digest[pos : pos + 4]
+            code_int = int.from_bytes(truncated, "big") & 0x7FFFFFFF
+            code = str(code_int % (10**self.digits)).zfill(self.digits)
+            codes.add(code)
+        return codes
+
+
+def _decode_base32(value: str) -> bytes:
+    padding = "=" * (-len(value) % 8)
+    return base64.b32decode((value + padding).upper())
+
+
+__all__ = [
+    "MfaChallengeError",
+    "MfaProvider",
+    "NullMfaProvider",
+    "TotpMfaProvider",
+]

--- a/services/identity/migrations/env.py
+++ b/services/identity/migrations/env.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+
+from services.identity.config import load_identity_settings
+from services.identity.database import Base, get_engine
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = load_identity_settings().database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = get_engine(load_identity_settings())
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/identity/migrations/versions/0001_initial_identity.py
+++ b/services/identity/migrations/versions/0001_initial_identity.py
@@ -1,0 +1,146 @@
+"""Initial identity service schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_identity"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "identity_tenants",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("slug", sa.String(length=64), nullable=False, unique=True, index=True),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("issuer", sa.String(length=256), nullable=False),
+        sa.Column("key_id", sa.String(length=128), nullable=False),
+        sa.Column("secret_provider", sa.String(length=32), nullable=False, server_default="vault"),
+        sa.Column("secret_reference", sa.String(length=256), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+    )
+
+    op.create_table(
+        "identity_roles",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("identity_tenants.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("tenant_id", "name", name="uq_identity_role_name"),
+    )
+
+    op.create_table(
+        "identity_users",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("identity_tenants.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("external_id", sa.String(length=128), nullable=True),
+        sa.Column("username", sa.String(length=128), nullable=False),
+        sa.Column("email", sa.String(length=256), nullable=True),
+        sa.Column("display_name", sa.String(length=256), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("is_service_account", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("mfa_enforced", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("mfa_secret", sa.String(length=256), nullable=True),
+        sa.Column("mfa_recovery_codes", sa.JSON(), nullable=False),
+        sa.Column("password_rotated_at", sa.DateTime(), nullable=True),
+        sa.Column("password_expires_at", sa.DateTime(), nullable=True),
+        sa.Column("api_key_last_rotated_at", sa.DateTime(), nullable=True),
+        sa.Column("api_key_expires_at", sa.DateTime(), nullable=True),
+        sa.Column("attributes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("tenant_id", "username", name="uq_identity_user_username"),
+        sa.UniqueConstraint("tenant_id", "email", name="uq_identity_user_email"),
+    )
+
+    op.create_table(
+        "identity_user_roles",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("identity_roles.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("assigned_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("user_id", "role_id", name="uq_identity_user_role"),
+    )
+
+    credential_type = sa.Enum("password", "api_key", "service", "refresh_token", name="credentialtype")
+    credential_type.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "identity_credentials",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("credential_type", credential_type, nullable=False, index=True),
+        sa.Column("secret_hash", sa.String(length=512), nullable=False),
+        sa.Column("secret_salt", sa.String(length=256), nullable=False),
+        sa.Column("secret_iterations", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("rotation_interval_days", sa.Integer(), nullable=False),
+        sa.Column("rotated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("external_secret_reference", sa.String(length=256), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "user_id",
+            "credential_type",
+            "version",
+            name="uq_identity_credential_version",
+        ),
+    )
+    op.create_index(
+        "ix_identity_credential_active",
+        "identity_credentials",
+        ["user_id", "credential_type", "is_active"],
+    )
+
+    op.create_table(
+        "identity_refresh_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_id", sa.String(length=128), nullable=False),
+        sa.Column("token_hash", sa.String(length=512), nullable=False),
+        sa.Column("token_salt", sa.String(length=256), nullable=False),
+        sa.Column("token_iterations", sa.Integer(), nullable=False),
+        sa.Column("client_id", sa.String(length=128), nullable=True),
+        sa.Column("issued_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "token_id", name="uq_identity_refresh_token"),
+    )
+    op.create_index(
+        "ix_identity_refresh_user",
+        "identity_refresh_tokens",
+        ["user_id", "revoked_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_identity_refresh_user", table_name="identity_refresh_tokens")
+    op.drop_table("identity_refresh_tokens")
+    op.drop_index("ix_identity_credential_active", table_name="identity_credentials")
+    op.drop_table("identity_credentials")
+    op.drop_table("identity_user_roles")
+    op.drop_table("identity_users")
+    op.drop_table("identity_roles")
+    op.drop_table("identity_tenants")
+    op.execute("DROP TYPE IF EXISTS credentialtype")

--- a/services/identity/models.py
+++ b/services/identity/models.py
@@ -1,0 +1,239 @@
+"""SQLAlchemy models backing the identity service."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class CredentialType(str, enum.Enum):
+    """Supported credential categories."""
+
+    PASSWORD = "password"
+    API_KEY = "api_key"
+    SERVICE = "service"
+    REFRESH_TOKEN = "refresh_token"
+
+
+class TenantModel(Base):
+    """Tenant metadata used for multi-tenant isolation."""
+
+    __tablename__ = "identity_tenants"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    issuer: Mapped[str] = mapped_column(String(256), nullable=False)
+    key_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    secret_provider: Mapped[str] = mapped_column(String(32), default="vault", nullable=False)
+    secret_reference: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    roles: Mapped[list["RoleModel"]] = relationship(
+        "RoleModel",
+        back_populates="tenant",
+        cascade="all, delete-orphan",
+    )
+    users: Mapped[list["UserModel"]] = relationship(
+        "UserModel",
+        back_populates="tenant",
+        cascade="all, delete-orphan",
+    )
+
+
+class RoleModel(Base):
+    """Role definitions scoped to a tenant."""
+
+    __tablename__ = "identity_roles"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", name="uq_identity_role_name"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    tenant: Mapped[TenantModel] = relationship("TenantModel", back_populates="roles")
+    users: Mapped[list["UserModel"]] = relationship(
+        "UserModel",
+        secondary="identity_user_roles",
+        back_populates="roles",
+    )
+
+
+class UserModel(Base):
+    """User accounts for both human and service identities."""
+
+    __tablename__ = "identity_users"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "username", name="uq_identity_user_username"),
+        UniqueConstraint("tenant_id", "email", name="uq_identity_user_email"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    external_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    username: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    email: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    display_name: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_service_account: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    mfa_enforced: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    mfa_secret: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    mfa_recovery_codes: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    password_rotated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    password_expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    api_key_last_rotated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    api_key_expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    attributes: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    last_login_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    tenant: Mapped[TenantModel] = relationship("TenantModel", back_populates="users")
+    roles: Mapped[list[RoleModel]] = relationship(
+        "RoleModel",
+        secondary="identity_user_roles",
+        back_populates="users",
+        lazy="joined",
+    )
+    credentials: Mapped[list["CredentialModel"]] = relationship(
+        "CredentialModel",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    refresh_tokens: Mapped[list["RefreshTokenModel"]] = relationship(
+        "RefreshTokenModel",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+
+class UserRoleLinkModel(Base):
+    """Association table linking users to roles."""
+
+    __tablename__ = "identity_user_roles"
+    __table_args__ = (
+        UniqueConstraint("user_id", "role_id", name="uq_identity_user_role"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False
+    )
+    role_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_roles.id", ondelete="CASCADE"), nullable=False
+    )
+    assigned_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class CredentialModel(Base):
+    """Secrets associated with a user."""
+
+    __tablename__ = "identity_credentials"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "user_id",
+            "credential_type",
+            "version",
+            name="uq_identity_credential_version",
+        ),
+        Index(
+            "ix_identity_credential_active",
+            "user_id",
+            "credential_type",
+            "is_active",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False
+    )
+    credential_type: Mapped[CredentialType] = mapped_column(
+        SAEnum(CredentialType), nullable=False, index=True
+    )
+    secret_hash: Mapped[str] = mapped_column(String(512), nullable=False)
+    secret_salt: Mapped[str] = mapped_column(String(256), nullable=False)
+    secret_iterations: Mapped[int] = mapped_column(Integer, default=210_000, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    rotation_interval_days: Mapped[int] = mapped_column(Integer, default=90, nullable=False)
+    rotated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    external_secret_reference: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user: Mapped[UserModel] = relationship("UserModel", back_populates="credentials")
+
+
+class RefreshTokenModel(Base):
+    """Persisted refresh tokens for session renewal."""
+
+    __tablename__ = "identity_refresh_tokens"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "token_id", name="uq_identity_refresh_token"),
+        Index("ix_identity_refresh_user", "user_id", "revoked_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("identity_users.id", ondelete="CASCADE"), nullable=False
+    )
+    token_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(512), nullable=False)
+    token_salt: Mapped[str] = mapped_column(String(256), nullable=False)
+    token_iterations: Mapped[int] = mapped_column(Integer, default=210_000, nullable=False)
+    client_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    issued_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    user: Mapped[UserModel] = relationship("UserModel", back_populates="refresh_tokens")
+
+
+__all__ = [
+    "CredentialModel",
+    "CredentialType",
+    "RefreshTokenModel",
+    "RoleModel",
+    "TenantModel",
+    "UserModel",
+    "UserRoleLinkModel",
+]

--- a/services/identity/schemas.py
+++ b/services/identity/schemas.py
@@ -1,0 +1,122 @@
+"""Pydantic schemas exposed by the identity service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TokenPair(BaseModel):
+    """Response returned when issuing or refreshing tokens."""
+
+    access_token: str = Field(description="Bearer token used for API access")
+    refresh_token: str = Field(description="Opaque token used to obtain new access tokens")
+    token_type: str = Field(default="Bearer")
+    expires_in: int = Field(description="Lifetime of the access token in seconds")
+    expires_at: datetime = Field(description="Timestamp when the access token expires")
+    issued_at: datetime = Field(description="Timestamp when the token pair was minted")
+    scope: List[str] = Field(default_factory=list, description="Scopes granted to the caller")
+    roles: List[str] = Field(default_factory=list, description="Roles granted to the caller")
+    username: str = Field(description="Username associated with the token")
+    tenant: str = Field(description="Tenant identifier for the subject")
+    password_expires_at: Optional[datetime] = None
+
+
+class IntrospectionResponse(BaseModel):
+    """Response payload for token introspection."""
+
+    active: bool
+    username: Optional[str] = None
+    subject: Optional[str] = None
+    tenant: Optional[str] = None
+    scope: List[str] = Field(default_factory=list)
+    roles: List[str] = Field(default_factory=list)
+    issued_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    token_type: Optional[str] = None
+    client_id: Optional[str] = None
+    claims: Dict[str, object] = Field(default_factory=dict)
+
+
+class CredentialRotationRequest(BaseModel):
+    """Payload for rotating a password or API key."""
+
+    username: str
+    current_secret: Optional[str] = Field(default=None)
+    new_secret: Optional[str] = Field(default=None)
+
+
+class CredentialRotationResponse(BaseModel):
+    """Metadata returned after rotating credentials."""
+
+    username: str
+    roles: List[str]
+    rotated_at: datetime
+    expires_at: Optional[datetime]
+    tenant: str
+
+
+class ApiKeyValidationResponse(BaseModel):
+    """Response returned when validating an API key."""
+
+    username: str
+    roles: List[str]
+    tenant: str
+    api_key_last_rotated_at: Optional[datetime]
+    api_key_expires_at: Optional[datetime]
+
+
+class ScimMeta(BaseModel):
+    """Subset of SCIM metadata returned with user resources."""
+
+    resourceType: str = Field(default="User")
+    created: datetime
+    lastModified: datetime
+    location: Optional[str] = None
+
+
+class ScimName(BaseModel):
+    """SCIM name representation."""
+
+    givenName: Optional[str] = None
+    familyName: Optional[str] = None
+    formatted: Optional[str] = None
+
+
+class ScimEmail(BaseModel):
+    """SCIM email representation."""
+
+    value: str
+    primary: bool = True
+    type: str = "work"
+
+
+class ScimUser(BaseModel):
+    """Simplified SCIM user representation."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    externalId: Optional[str] = None
+    userName: str
+    name: Optional[ScimName] = None
+    active: bool = True
+    emails: List[ScimEmail] = Field(default_factory=list)
+    displayName: Optional[str] = None
+    roles: List[Dict[str, str]] = Field(default_factory=list)
+    meta: Optional[ScimMeta] = None
+
+
+__all__ = [
+    "ApiKeyValidationResponse",
+    "CredentialRotationRequest",
+    "CredentialRotationResponse",
+    "IntrospectionResponse",
+    "ScimEmail",
+    "ScimMeta",
+    "ScimName",
+    "ScimUser",
+    "TokenPair",
+]

--- a/services/identity/scim.py
+++ b/services/identity/scim.py
@@ -1,0 +1,129 @@
+"""SCIM helper utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from .models import RoleModel, UserModel
+from .schemas import ScimEmail, ScimMeta, ScimName, ScimUser
+
+
+@dataclass(slots=True)
+class ScimUpdate:
+    """Normalised SCIM attributes extracted from API requests."""
+
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+    active: Optional[bool] = None
+    role_names: Optional[List[str]] = None
+    attributes: Dict[str, object] = field(default_factory=dict)
+
+
+def build_scim_user(user: UserModel, base_url: str) -> ScimUser:
+    """Convert a :class:`UserModel` into a SCIM-compatible payload."""
+
+    meta = ScimMeta(
+        created=user.created_at,
+        lastModified=user.updated_at,
+        location=f"{base_url.rstrip('/')}/scim/v2/Users/{user.id}",
+    )
+    name_attrs = user.attributes.get("name") if isinstance(user.attributes, dict) else {}
+    scim_name = None
+    if name_attrs:
+        scim_name = ScimName(
+            givenName=name_attrs.get("givenName"),
+            familyName=name_attrs.get("familyName"),
+            formatted=name_attrs.get("formatted"),
+        )
+    emails: List[ScimEmail] = []
+    if user.email:
+        emails.append(ScimEmail(value=user.email, primary=True))
+    roles = [
+        {"value": role.name, "display": role.description or role.name}
+        for role in user.roles
+    ]
+    return ScimUser(
+        id=str(user.id),
+        externalId=user.external_id,
+        userName=user.username,
+        active=user.is_active,
+        emails=emails,
+        displayName=user.display_name,
+        roles=roles,
+        name=scim_name,
+        meta=meta,
+    )
+
+
+def parse_scim_payload(payload: Dict[str, object]) -> ScimUpdate:
+    """Extract SCIM attributes for persistence."""
+
+    update = ScimUpdate()
+    update.username = str(payload.get("userName")) if payload.get("userName") else None
+    update.display_name = payload.get("displayName") or None
+    if "active" in payload:
+        update.active = bool(payload["active"])
+
+    name_payload = payload.get("name")
+    if isinstance(name_payload, dict):
+        update.attributes.setdefault("name", {})
+        update.attributes["name"] = {
+            "givenName": name_payload.get("givenName"),
+            "familyName": name_payload.get("familyName"),
+            "formatted": name_payload.get("formatted"),
+        }
+
+    emails_payload = payload.get("emails")
+    if isinstance(emails_payload, list) and emails_payload:
+        primary = None
+        for entry in emails_payload:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("primary"):
+                primary = entry
+                break
+        primary = primary or emails_payload[0]
+        update.email = primary.get("value") if isinstance(primary, dict) else None
+
+    roles_payload = payload.get("roles")
+    if isinstance(roles_payload, list):
+        names = []
+        for entry in roles_payload:
+            if isinstance(entry, dict):
+                value = entry.get("value") or entry.get("display")
+                if value:
+                    names.append(str(value))
+            elif entry:
+                names.append(str(entry))
+        if names:
+            update.role_names = names
+
+    return update
+
+
+def apply_scim_update(user: UserModel, update: ScimUpdate, roles: List[RoleModel]) -> None:
+    """Apply the SCIM update to the SQLAlchemy model."""
+
+    if update.username:
+        user.username = update.username
+    if update.display_name is not None:
+        user.display_name = update.display_name
+    if update.email is not None:
+        user.email = update.email
+    if update.active is not None:
+        user.is_active = update.active
+    if update.attributes:
+        base_attrs = dict(user.attributes or {})
+        base_attrs.update(update.attributes)
+        user.attributes = base_attrs
+    if update.role_names is not None:
+        role_map = {role.name: role for role in roles}
+        selected = [role_map[name] for name in update.role_names if name in role_map]
+        user.roles = selected
+    user.updated_at = datetime.utcnow()
+
+
+__all__ = ["ScimUpdate", "apply_scim_update", "build_scim_user", "parse_scim_payload"]

--- a/services/identity/security.py
+++ b/services/identity/security.py
@@ -1,0 +1,88 @@
+"""Security utilities for credential handling."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_HASH_ITERATIONS = 320_000
+_SALT_BYTES = 24
+
+
+@dataclass(slots=True)
+class HashedSecret:
+    """Container describing a hashed secret."""
+
+    hash: str
+    salt: str
+    iterations: int = DEFAULT_HASH_ITERATIONS
+
+
+def _encode_bytes(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii")
+
+
+def _decode_to_bytes(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode((value or "").encode("ascii") + padding.encode("ascii"))
+
+
+def generate_salt(length: int = _SALT_BYTES) -> str:
+    """Return a random salt encoded as URL safe base64."""
+
+    return _encode_bytes(os.urandom(length))
+
+
+def hash_secret(
+    secret: str,
+    *,
+    salt: Optional[str] = None,
+    iterations: int = DEFAULT_HASH_ITERATIONS,
+) -> HashedSecret:
+    """Derive a PBKDF2-HMAC hash for the provided secret."""
+
+    if not secret:
+        raise ValueError("Secret value must be provided")
+
+    salt_value = salt or generate_salt()
+    salt_bytes = _decode_to_bytes(salt_value)
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        secret.encode("utf-8"),
+        salt_bytes,
+        iterations,
+    )
+    return HashedSecret(hash=_encode_bytes(derived), salt=salt_value, iterations=iterations)
+
+
+def verify_secret(secret: str, hashed: HashedSecret) -> bool:
+    """Check if *secret* matches the stored hash."""
+
+    if not secret:
+        return False
+    candidate = hash_secret(secret, salt=hashed.salt, iterations=hashed.iterations)
+    return hmac.compare_digest(candidate.hash, hashed.hash)
+
+
+def generate_token(length: int = 32) -> str:
+    """Return a cryptographically secure random token."""
+
+    # ``token_urlsafe`` returns roughly 1.3 characters per byte. The ``length``
+    # parameter therefore controls the resulting entropy without forcing
+    # callers to reason about byte lengths.
+    return secrets.token_urlsafe(length)
+
+
+__all__ = [
+    "DEFAULT_HASH_ITERATIONS",
+    "HashedSecret",
+    "generate_salt",
+    "generate_token",
+    "hash_secret",
+    "verify_secret",
+]

--- a/services/identity/service.py
+++ b/services/identity/service.py
@@ -1,0 +1,722 @@
+"""Core business logic for the identity microservice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, List, Optional, Sequence
+
+import jwt
+from sqlalchemy import and_, func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, joinedload
+
+from .config import IdentitySettings, load_identity_settings
+from .database import Base, get_engine, get_session
+from .mfa import MfaProvider, NullMfaProvider
+from .models import (
+    CredentialModel,
+    CredentialType,
+    RefreshTokenModel,
+    RoleModel,
+    TenantModel,
+    UserModel,
+)
+from .schemas import IntrospectionResponse, ScimUser, TokenPair
+from .scim import ScimUpdate, apply_scim_update, build_scim_user, parse_scim_payload
+from .security import HashedSecret, generate_token, hash_secret, verify_secret
+from .tokens import TokenSigner
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class IdentityError(RuntimeError):
+    """Base class for identity related exceptions."""
+
+
+class InvalidCredentialsError(IdentityError):
+    """Raised when credentials cannot be validated."""
+
+
+class InactiveAccountError(IdentityError):
+    """Raised when an account has been disabled."""
+
+
+class PasswordExpiredError(IdentityError):
+    """Raised when a password must be rotated before continuing."""
+
+
+class ApiKeyValidationError(IdentityError):
+    """Raised when an API key does not match any user."""
+
+
+class ApiKeyRotationRequiredError(ApiKeyValidationError):
+    """Raised when an API key has exceeded its rotation deadline."""
+
+
+class RefreshTokenError(IdentityError):
+    """Raised when refresh token validation fails."""
+
+
+class ScimOperationError(IdentityError):
+    """Raised when SCIM provisioning fails."""
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class IdentityUser:
+    """Serializable representation of a user."""
+
+    id: int
+    tenant: str
+    username: str
+    roles: List[str]
+    is_active: bool
+    password_rotated_at: Optional[datetime]
+    password_expires_at: Optional[datetime]
+    api_key_last_rotated_at: Optional[datetime]
+    api_key_expires_at: Optional[datetime]
+
+
+# ---------------------------------------------------------------------------
+# Identity service implementation
+# ---------------------------------------------------------------------------
+
+
+class IdentityService:
+    """Identity and credential management service."""
+
+    def __init__(
+        self,
+        settings: Optional[IdentitySettings] = None,
+        *,
+        mfa_provider: Optional[MfaProvider] = None,
+    ) -> None:
+        self.settings = settings or load_identity_settings()
+        self.mfa_provider = mfa_provider or NullMfaProvider()
+        self.token_signer = TokenSigner(self.settings)
+        self._initialise_schema()
+        self._ensure_default_tenant()
+
+    # ------------------------------------------------------------------
+    # Initialisation helpers
+    # ------------------------------------------------------------------
+    def _initialise_schema(self) -> None:
+        engine = get_engine(self.settings)
+        Base.metadata.create_all(engine)
+
+    def _ensure_default_tenant(self) -> None:
+        with get_session(self.settings) as session:
+            stmt = select(TenantModel).where(TenantModel.slug == self.settings.default_tenant_slug)
+            tenant = session.scalar(stmt)
+            if tenant:
+                return
+            issuer = self._build_tenant_issuer(self.settings.default_tenant_slug)
+            secret_reference = f"tenants/{self.settings.default_tenant_slug}/identity"
+            tenant = TenantModel(
+                slug=self.settings.default_tenant_slug,
+                name="Default Tenant",
+                issuer=issuer,
+                key_id=f"{self.settings.default_tenant_slug}-default",
+                secret_reference=secret_reference,
+                secret_provider="vault",
+                metadata_json={"token_algorithm": self.settings.token_algorithm},
+            )
+            session.add(tenant)
+
+    def _build_tenant_issuer(self, slug: str) -> str:
+        base = self.settings.default_issuer.rstrip("/")
+        return f"{base}/{slug}"
+
+    # ------------------------------------------------------------------
+    # Tenant helpers
+    # ------------------------------------------------------------------
+    def _resolve_tenant(self, session: Session, slug: Optional[str]) -> TenantModel:
+        tenant_slug = slug or self.settings.default_tenant_slug
+        stmt = select(TenantModel).where(TenantModel.slug == tenant_slug)
+        tenant = session.scalar(stmt)
+        if not tenant:
+            raise IdentityError(f"Unknown tenant '{tenant_slug}'")
+        if not tenant.is_active:
+            raise IdentityError(f"Tenant '{tenant_slug}' is disabled")
+        return tenant
+
+    # ------------------------------------------------------------------
+    # Token issuance and validation
+    # ------------------------------------------------------------------
+    def issue_token(
+        self,
+        tenant_slug: Optional[str],
+        username: str,
+        password: str,
+        *,
+        scope: Optional[Sequence[str]] = None,
+        requested_scopes: Optional[str] = None,
+        mfa_code: Optional[str] = None,
+    ) -> TokenPair:
+        scopes = self._normalise_scopes(scope, requested_scopes)
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._require_user(session, tenant, username)
+            self._validate_user_password(user, password)
+            if self.mfa_provider.is_required(user):
+                if not self.mfa_provider.verify(user, mfa_code or ""):
+                    raise InvalidCredentialsError("Multi-factor challenge failed")
+            token_pair = self._mint_tokens(session, tenant, user, scopes)
+            return token_pair
+
+    def refresh_token(
+        self,
+        tenant_slug: Optional[str],
+        refresh_token: str,
+        *,
+        scope: Optional[Sequence[str]] = None,
+    ) -> TokenPair:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant_from_token(session, tenant_slug, refresh_token)
+            claims = self.token_signer.verify_token(tenant, refresh_token)
+            if claims.get("type") != "refresh":
+                raise RefreshTokenError("Provided token is not a refresh token")
+            jti = str(claims.get("jti")) if claims.get("jti") else None
+            if not jti:
+                raise RefreshTokenError("Refresh token missing identifier")
+            stmt = (
+                select(RefreshTokenModel)
+                .where(
+                    and_(
+                        RefreshTokenModel.tenant_id == tenant.id,
+                        RefreshTokenModel.token_id == jti,
+                        RefreshTokenModel.revoked_at.is_(None),
+                    )
+                )
+                .options(joinedload(RefreshTokenModel.user).joinedload(UserModel.roles))
+            )
+            model = session.scalar(stmt)
+            if not model:
+                raise RefreshTokenError("Refresh token has been revoked or is unknown")
+            if model.expires_at < self._utcnow():
+                model.revoked_at = self._utcnow()
+                session.add(model)
+                raise RefreshTokenError("Refresh token has expired")
+            if not verify_secret(refresh_token, self._hashed_refresh_secret(model)):
+                model.revoked_at = self._utcnow()
+                session.add(model)
+                raise RefreshTokenError("Refresh token validation failed")
+            user = model.user
+            if not user.is_active:
+                raise InactiveAccountError("Account disabled")
+            scopes = self._normalise_scopes(scope, None)
+            model.revoked_at = self._utcnow()
+            session.add(model)
+            return self._mint_tokens(session, tenant, user, scopes)
+
+    def introspect_token(
+        self,
+        tenant_slug: Optional[str],
+        token: str,
+    ) -> IntrospectionResponse:
+        with get_session(self.settings) as session:
+            try:
+                tenant = self._resolve_tenant_from_token(session, tenant_slug, token)
+            except IdentityError:
+                return IntrospectionResponse(active=False)
+            try:
+                claims = self.token_signer.verify_token(tenant, token)
+            except Exception:
+                return IntrospectionResponse(active=False)
+
+            roles = self._extract_roles_from_claims(claims)
+            scope = self._extract_scopes_from_claims(claims)
+            issued = datetime.fromtimestamp(int(claims.get("iat", 0)), tz=timezone.utc)
+            expires = datetime.fromtimestamp(int(claims.get("exp", 0)), tz=timezone.utc)
+            return IntrospectionResponse(
+                active=True,
+                username=str(claims.get("sub")),
+                subject=str(claims.get("sub")),
+                tenant=tenant.slug,
+                scope=scope,
+                roles=roles,
+                issued_at=issued,
+                expires_at=expires,
+                token_type=str(claims.get("type", "access")),
+                client_id=str(claims.get("client_id")) if claims.get("client_id") else None,
+                claims=claims,
+            )
+
+    # ------------------------------------------------------------------
+    # Credential management
+    # ------------------------------------------------------------------
+    def rotate_password(
+        self,
+        tenant_slug: Optional[str],
+        username: str,
+        current_password: str,
+        new_password: str,
+    ) -> IdentityUser:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._require_user(session, tenant, username)
+            self._validate_user_password(user, current_password)
+            credential = self._rotate_secret(
+                session,
+                user,
+                CredentialType.PASSWORD,
+                new_password,
+            )
+            user.password_rotated_at = credential.rotated_at
+            user.password_expires_at = credential.expires_at
+            session.add(user)
+            session.flush()
+            return self._to_identity_user(user)
+
+    def rotate_api_key(
+        self,
+        tenant_slug: Optional[str],
+        username: str,
+        *,
+        new_api_key: Optional[str] = None,
+    ) -> tuple[str, IdentityUser]:
+        api_key = new_api_key or generate_token(48)
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._require_user(session, tenant, username)
+            credential = self._rotate_secret(
+                session,
+                user,
+                CredentialType.API_KEY,
+                api_key,
+                rotation_interval_days=180,
+            )
+            user.api_key_last_rotated_at = credential.rotated_at
+            user.api_key_expires_at = credential.expires_at
+            session.add(user)
+            session.flush()
+            return api_key, self._to_identity_user(user)
+
+    def validate_api_key(
+        self,
+        tenant_slug: Optional[str],
+        api_key: str,
+    ) -> IdentityUser:
+        if not api_key:
+            raise ApiKeyValidationError("API key cannot be empty")
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            stmt = (
+                select(CredentialModel)
+                .join(UserModel)
+                .where(
+                    and_(
+                        CredentialModel.tenant_id == tenant.id,
+                        CredentialModel.credential_type == CredentialType.API_KEY,
+                        CredentialModel.is_active.is_(True),
+                    )
+                )
+                .options(
+                    joinedload(CredentialModel.user).joinedload(UserModel.roles),
+                    joinedload(CredentialModel.user).joinedload(UserModel.tenant),
+                )
+            )
+            for credential in session.scalars(stmt):
+                if verify_secret(api_key, self._hashed_secret(credential)):
+                    if credential.expires_at and credential.expires_at < self._utcnow():
+                        raise ApiKeyRotationRequiredError("API key has expired and must be rotated")
+                    user = credential.user
+                    if not user.is_active:
+                        raise InactiveAccountError("Account disabled")
+                    return self._to_identity_user(user)
+        raise ApiKeyValidationError("Invalid API key")
+
+    def list_users(self, tenant_slug: Optional[str]) -> List[IdentityUser]:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            stmt = (
+                select(UserModel)
+                .where(UserModel.tenant_id == tenant.id)
+                .options(joinedload(UserModel.roles), joinedload(UserModel.tenant))
+            )
+            return [self._to_identity_user(user) for user in session.scalars(stmt)]
+
+    # ------------------------------------------------------------------
+    # SCIM provisioning
+    # ------------------------------------------------------------------
+    def scim_list_users(self, tenant_slug: Optional[str], base_url: str) -> List[ScimUser]:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            stmt = (
+                select(UserModel)
+                .where(UserModel.tenant_id == tenant.id)
+                .options(joinedload(UserModel.roles), joinedload(UserModel.tenant))
+            )
+            return [build_scim_user(user, base_url) for user in session.scalars(stmt)]
+
+    def scim_get_user(self, tenant_slug: Optional[str], user_id: int, base_url: str) -> ScimUser:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._get_user_by_id(session, tenant, user_id)
+            if not user:
+                raise ScimOperationError("User not found")
+            return build_scim_user(user, base_url)
+
+    def scim_create_user(
+        self,
+        tenant_slug: Optional[str],
+        payload: dict,
+        base_url: str,
+    ) -> ScimUser:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            update = parse_scim_payload(payload)
+            password = payload.get("password")
+            if not password:
+                raise ScimOperationError("SCIM payload must include 'password'")
+            user = UserModel(
+                tenant_id=tenant.id,
+                username=update.username or payload.get("userName"),
+                display_name=update.display_name,
+                email=update.email,
+                is_active=update.active if update.active is not None else True,
+                attributes=update.attributes or {},
+                external_id=payload.get("externalId"),
+            )
+            session.add(user)
+            session.flush()
+            self._rotate_secret(session, user, CredentialType.PASSWORD, password)
+            self._assign_roles(session, tenant, user, update.role_names or [])
+            session.flush()
+            user.tenant = tenant
+            return build_scim_user(user, base_url)
+
+    def scim_replace_user(
+        self,
+        tenant_slug: Optional[str],
+        user_id: int,
+        payload: dict,
+        base_url: str,
+    ) -> ScimUser:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._get_user_by_id(session, tenant, user_id)
+            if not user:
+                raise ScimOperationError("User not found")
+            update = parse_scim_payload(payload)
+            apply_scim_update(user, update, self._ensure_roles(session, tenant, update.role_names or []))
+            session.add(user)
+            session.flush()
+            if password := payload.get("password"):
+                self._rotate_secret(session, user, CredentialType.PASSWORD, password)
+            return build_scim_user(user, base_url)
+
+    def scim_delete_user(self, tenant_slug: Optional[str], user_id: int) -> None:
+        with get_session(self.settings) as session:
+            tenant = self._resolve_tenant(session, tenant_slug)
+            user = self._get_user_by_id(session, tenant, user_id)
+            if not user:
+                return
+            session.delete(user)
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _mint_tokens(
+        self,
+        session: Session,
+        tenant: TenantModel,
+        user: UserModel,
+        scopes: Sequence[str],
+    ) -> TokenPair:
+        roles = [role.name for role in user.roles]
+        access_token, issued_at, expires_at, _ = self.token_signer.mint_access_token(
+            tenant,
+            user.username,
+            list(scopes),
+            roles,
+            self.settings.access_token_ttl_seconds,
+            additional_claims={
+                "type": "access",
+                "password_expires_at": int(user.password_expires_at.timestamp())
+                if user.password_expires_at
+                else None,
+            },
+        )
+        refresh_token, refresh_issued, refresh_expires, refresh_jti = self.token_signer.mint_refresh_token(
+            tenant,
+            user.username,
+            self.settings.refresh_token_ttl_seconds,
+        )
+        hashed_refresh = hash_secret(refresh_token)
+        refresh_model = RefreshTokenModel(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            token_id=refresh_jti,
+            token_hash=hashed_refresh.hash,
+            token_salt=hashed_refresh.salt,
+            token_iterations=hashed_refresh.iterations,
+            issued_at=refresh_issued,
+            expires_at=refresh_expires,
+        )
+        session.add(refresh_model)
+        user.last_login_at = self._utcnow()
+        session.add(user)
+        session.flush()
+        return TokenPair(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=self.settings.access_token_ttl_seconds,
+            expires_at=expires_at,
+            issued_at=issued_at,
+            scope=list(scopes),
+            roles=roles,
+            username=user.username,
+            tenant=tenant.slug,
+            password_expires_at=user.password_expires_at,
+        )
+
+    def _rotate_secret(
+        self,
+        session: Session,
+        user: UserModel,
+        credential_type: CredentialType,
+        secret: str,
+        *,
+        rotation_interval_days: int = 90,
+    ) -> CredentialModel:
+        hashed = hash_secret(secret)
+        self._deactivate_credentials(session, user, credential_type)
+        version_stmt = select(func.max(CredentialModel.version)).where(
+            and_(
+                CredentialModel.user_id == user.id,
+                CredentialModel.credential_type == credential_type,
+            )
+        )
+        latest_version = session.scalar(version_stmt) or 0
+        rotated_at = self._utcnow()
+        expires_at = rotated_at + timedelta(days=rotation_interval_days)
+        credential = CredentialModel(
+            tenant_id=user.tenant_id,
+            user_id=user.id,
+            credential_type=credential_type,
+            secret_hash=hashed.hash,
+            secret_salt=hashed.salt,
+            secret_iterations=hashed.iterations,
+            version=latest_version + 1,
+            rotation_interval_days=rotation_interval_days,
+            rotated_at=rotated_at,
+            expires_at=expires_at,
+            is_active=True,
+        )
+        session.add(credential)
+        session.flush()
+        return credential
+
+    def _deactivate_credentials(
+        self,
+        session: Session,
+        user: UserModel,
+        credential_type: CredentialType,
+    ) -> None:
+        stmt = (
+            select(CredentialModel)
+            .where(
+                and_(
+                    CredentialModel.user_id == user.id,
+                    CredentialModel.credential_type == credential_type,
+                    CredentialModel.is_active.is_(True),
+                )
+            )
+        )
+        for credential in session.scalars(stmt):
+            credential.is_active = False
+            session.add(credential)
+
+    def _assign_roles(
+        self,
+        session: Session,
+        tenant: TenantModel,
+        user: UserModel,
+        role_names: Iterable[str],
+    ) -> None:
+        roles = self._ensure_roles(session, tenant, role_names)
+        user.roles = roles
+        session.add(user)
+
+    def _ensure_roles(
+        self,
+        session: Session,
+        tenant: TenantModel,
+        role_names: Iterable[str],
+    ) -> List[RoleModel]:
+        existing_stmt = (
+            select(RoleModel)
+            .where(
+                and_(
+                    RoleModel.tenant_id == tenant.id,
+                    RoleModel.name.in_(list(role_names) or [""]),
+                )
+            )
+        )
+        existing = {role.name: role for role in session.scalars(existing_stmt)}
+        roles: List[RoleModel] = []
+        for name in role_names:
+            if not name:
+                continue
+            role = existing.get(name)
+            if not role:
+                role = RoleModel(tenant_id=tenant.id, name=name, description=f"SCIM role {name}")
+                session.add(role)
+                try:
+                    session.flush()
+                except IntegrityError:
+                    session.rollback()
+                    stmt = (
+                        select(RoleModel)
+                        .where(
+                            and_(
+                                RoleModel.tenant_id == tenant.id,
+                                RoleModel.name == name,
+                            )
+                        )
+                    )
+                    role = session.scalar(stmt)
+                    if not role:
+                        raise
+            roles.append(role)
+        return roles
+
+    def _require_user(self, session: Session, tenant: TenantModel, username: str) -> UserModel:
+        stmt = (
+            select(UserModel)
+            .where(
+                and_(UserModel.tenant_id == tenant.id, UserModel.username == username)
+            )
+            .options(joinedload(UserModel.roles), joinedload(UserModel.tenant))
+        )
+        user = session.scalar(stmt)
+        if not user:
+            raise InvalidCredentialsError("Invalid username or password")
+        if not user.is_active:
+            raise InactiveAccountError("Account disabled")
+        return user
+
+    def _get_user_by_id(
+        self, session: Session, tenant: TenantModel, user_id: int
+    ) -> Optional[UserModel]:
+        stmt = (
+            select(UserModel)
+            .where(and_(UserModel.tenant_id == tenant.id, UserModel.id == user_id))
+            .options(joinedload(UserModel.roles), joinedload(UserModel.tenant))
+        )
+        return session.scalar(stmt)
+
+    def _validate_user_password(self, user: UserModel, password: str) -> None:
+        credential = self._active_credential(user, CredentialType.PASSWORD)
+        if not credential or not verify_secret(password, self._hashed_secret(credential)):
+            raise InvalidCredentialsError("Invalid username or password")
+        if credential.expires_at and credential.expires_at < self._utcnow():
+            raise PasswordExpiredError("Password expired; rotation required")
+
+    def _active_credential(
+        self, user: UserModel, credential_type: CredentialType
+    ) -> Optional[CredentialModel]:
+        for credential in sorted(
+            (cred for cred in user.credentials if cred.credential_type == credential_type and cred.is_active),
+            key=lambda cred: cred.version,
+            reverse=True,
+        ):
+            return credential
+        return None
+
+    def _resolve_tenant_from_token(
+        self,
+        session: Session,
+        tenant_slug: Optional[str],
+        token: str,
+    ) -> TenantModel:
+        if tenant_slug:
+            return self._resolve_tenant(session, tenant_slug)
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except Exception as exc:
+            raise IdentityError("Unable to determine tenant from token") from exc
+        slug = claims.get("tenant") or claims.get("tid")
+        return self._resolve_tenant(session, slug)
+
+    def _to_identity_user(self, user: UserModel) -> IdentityUser:
+        roles = [role.name for role in user.roles]
+        return IdentityUser(
+            id=user.id,
+            tenant=user.tenant.slug if user.tenant else "",
+            username=user.username,
+            roles=roles,
+            is_active=user.is_active,
+            password_rotated_at=user.password_rotated_at,
+            password_expires_at=user.password_expires_at,
+            api_key_last_rotated_at=user.api_key_last_rotated_at,
+            api_key_expires_at=user.api_key_expires_at,
+        )
+
+    def _hashed_secret(self, credential: CredentialModel) -> HashedSecret:
+        return HashedSecret(
+            hash=credential.secret_hash,
+            salt=credential.secret_salt,
+            iterations=credential.secret_iterations,
+        )
+
+    def _hashed_refresh_secret(self, model: RefreshTokenModel) -> HashedSecret:
+        return HashedSecret(
+            hash=model.token_hash,
+            salt=model.token_salt,
+            iterations=model.token_iterations,
+        )
+
+    def _normalise_scopes(
+        self,
+        scope_list: Optional[Sequence[str]],
+        scope_string: Optional[str],
+    ) -> List[str]:
+        scopes = set(scope_list or [])
+        if scope_string:
+            scopes.update(scope for scope in scope_string.split() if scope)
+        scopes.add("openid")
+        scopes.add("profile")
+        return sorted(scopes)
+
+    def _extract_roles_from_claims(self, claims: dict) -> List[str]:
+        roles = claims.get("roles")
+        if isinstance(roles, list):
+            return [str(role) for role in roles]
+        if isinstance(roles, str):
+            return [role for role in roles.split() if role]
+        return []
+
+    def _extract_scopes_from_claims(self, claims: dict) -> List[str]:
+        scope = claims.get("scope")
+        if isinstance(scope, str):
+            return [part for part in scope.split() if part]
+        if isinstance(scope, list):
+            return [str(part) for part in scope]
+        return []
+
+    def _utcnow(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "ApiKeyRotationRequiredError",
+    "ApiKeyValidationError",
+    "IdentityError",
+    "IdentityService",
+    "IdentityUser",
+    "InactiveAccountError",
+    "InvalidCredentialsError",
+    "PasswordExpiredError",
+    "RefreshTokenError",
+    "ScimOperationError",
+]

--- a/services/identity/tokens.py
+++ b/services/identity/tokens.py
@@ -1,0 +1,272 @@
+"""Token management helpers for the identity service."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from services.common.secrets import SecretRetrievalError, resolve_secret
+
+from .config import IdentitySettings
+from .models import TenantModel
+
+
+@dataclass(slots=True)
+class TenantSigningKey:
+    """Represents signing material for a tenant."""
+
+    tenant_slug: str
+    key_id: str
+    algorithm: str
+    private_key_pem: Optional[str] = None
+    public_key_pem: Optional[str] = None
+    shared_secret: Optional[str] = None
+    last_loaded_at: datetime = datetime.now(timezone.utc)
+
+    def as_public_jwk(self) -> Optional[Dict[str, str]]:
+        """Return the JWK representation of the signing key if possible."""
+
+        if self.algorithm.upper().startswith("HS"):
+            # Symmetric keys are not exposed via JWKS for security reasons.
+            return None
+        if not self.public_key_pem:
+            return None
+        public_key = serialization.load_pem_public_key(self.public_key_pem.encode("utf-8"))
+        assert isinstance(public_key, rsa.RSAPublicKey)
+        numbers = public_key.public_numbers()
+        return {
+            "kty": "RSA",
+            "use": "sig",
+            "alg": self.algorithm,
+            "kid": self.key_id,
+            "n": _int_to_base64(numbers.n),
+            "e": _int_to_base64(numbers.e),
+        }
+
+
+def _int_to_base64(value: int) -> str:
+    byte_length = (value.bit_length() + 7) // 8
+    return base64.urlsafe_b64encode(value.to_bytes(byte_length, "big")).rstrip(b"=").decode("ascii")
+
+
+def _generate_jti() -> str:
+    from uuid import uuid4
+
+    return uuid4().hex
+
+
+class TokenSigner:
+    """Create and validate JWT tokens for tenants."""
+
+    def __init__(self, settings: IdentitySettings) -> None:
+        self.settings = settings
+        self._cache: Dict[str, TenantSigningKey] = {}
+
+    # ------------------------------------------------------------------
+    # Key loading helpers
+    # ------------------------------------------------------------------
+    def get_signing_key(self, tenant: TenantModel) -> TenantSigningKey:
+        cached = self._cache.get(tenant.slug)
+        if cached:
+            return cached
+
+        signing_material = self._load_signing_material(tenant)
+        self._cache[tenant.slug] = signing_material
+        return signing_material
+
+    def _load_signing_material(self, tenant: TenantModel) -> TenantSigningKey:
+        env_keys = [
+            f"IDENTITY_{tenant.slug.upper()}_SIGNING_KEY",
+            "IDENTITY_SIGNING_KEY",
+        ]
+        try:
+            raw_secret = resolve_secret(
+                "OIDC_SIGNING_KEY",
+                env_keys=env_keys,
+                vault_path=tenant.secret_reference,
+            )
+        except SecretRetrievalError:
+            if not self.settings.allow_development_fallback_keys:
+                raise
+            private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            private_pem = private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            ).decode("utf-8")
+            public_pem = private_key.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ).decode("utf-8")
+            signing_key = TenantSigningKey(
+                tenant_slug=tenant.slug,
+                key_id=tenant.key_id,
+                algorithm=self.settings.token_algorithm,
+                private_key_pem=private_pem,
+                public_key_pem=public_pem,
+            )
+            return signing_key
+
+        algorithm = tenant.metadata_json.get("token_algorithm") or self.settings.token_algorithm
+        private_pem: Optional[str] = None
+        public_pem: Optional[str] = None
+        shared_secret: Optional[str] = None
+
+        stripped = raw_secret.strip()
+        if stripped.startswith("{"):
+            data = json.loads(stripped)
+            private_pem = data.get("private_key") or data.get("privateKey")
+            public_pem = data.get("public_key") or data.get("publicKey")
+            shared_secret = data.get("shared_secret") or data.get("secret")
+            algorithm = data.get("algorithm") or algorithm
+        else:
+            if algorithm.upper().startswith("HS"):
+                shared_secret = stripped
+            else:
+                private_pem = stripped
+
+        signing_key = TenantSigningKey(
+            tenant_slug=tenant.slug,
+            key_id=tenant.key_id,
+            algorithm=algorithm,
+            private_key_pem=private_pem,
+            public_key_pem=public_pem,
+            shared_secret=shared_secret,
+        )
+
+        if signing_key.private_key_pem and not signing_key.public_key_pem:
+            private_key = serialization.load_pem_private_key(
+                signing_key.private_key_pem.encode("utf-8"),
+                password=None,
+            )
+            assert isinstance(private_key, rsa.RSAPrivateKey)
+            signing_key.public_key_pem = private_key.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ).decode("utf-8")
+        return signing_key
+
+    # ------------------------------------------------------------------
+    # Token issuance
+    # ------------------------------------------------------------------
+    def mint_access_token(
+        self,
+        tenant: TenantModel,
+        subject: str,
+        scopes: list[str],
+        roles: list[str],
+        expires_in: int,
+        *,
+        audience: Optional[str] = None,
+        additional_claims: Optional[Dict[str, object]] = None,
+    ) -> tuple[str, datetime, datetime, str]:
+        """Return an encoded JWT access token."""
+
+        issued_at = datetime.now(timezone.utc)
+        expires_at = issued_at + timedelta(seconds=expires_in)
+        jti = _generate_jti()
+        payload: Dict[str, object] = {
+            "sub": subject,
+            "iss": tenant.issuer,
+            "iat": int(issued_at.timestamp()),
+            "exp": int(expires_at.timestamp()),
+            "scope": " ".join(scopes),
+            "roles": roles,
+            "tenant": tenant.slug,
+            "jti": jti,
+        }
+        if audience:
+            payload["aud"] = audience
+        if additional_claims:
+            payload.update(additional_claims)
+
+        signing_key = self.get_signing_key(tenant)
+        headers = {"kid": tenant.key_id, "typ": "JWT"}
+        token = jwt.encode(
+            payload,
+            self._jwt_signing_value(signing_key),
+            algorithm=signing_key.algorithm,
+            headers=headers,
+        )
+        return token, issued_at, expires_at, jti
+
+    def mint_refresh_token(
+        self,
+        tenant: TenantModel,
+        subject: str,
+        expires_in: int,
+        *,
+        client_id: Optional[str] = None,
+    ) -> tuple[str, datetime, datetime, str]:
+        issued_at = datetime.now(timezone.utc)
+        expires_at = issued_at + timedelta(seconds=expires_in)
+        jti = _generate_jti()
+        payload: Dict[str, object] = {
+            "sub": subject,
+            "iss": tenant.issuer,
+            "iat": int(issued_at.timestamp()),
+            "exp": int(expires_at.timestamp()),
+            "tenant": tenant.slug,
+            "type": "refresh",
+            "jti": jti,
+        }
+        if client_id:
+            payload["client_id"] = client_id
+
+        signing_key = self.get_signing_key(tenant)
+        headers = {"kid": tenant.key_id, "typ": "JWT"}
+        token = jwt.encode(
+            payload,
+            self._jwt_signing_value(signing_key),
+            algorithm=signing_key.algorithm,
+            headers=headers,
+        )
+        return token, issued_at, expires_at, jti
+
+    def verify_token(
+        self,
+        tenant: TenantModel,
+        token: str,
+        *,
+        audience: Optional[str] = None,
+    ) -> Dict[str, object]:
+        signing_key = self.get_signing_key(tenant)
+        options = {"verify_aud": audience is not None}
+        verified = jwt.decode(
+            token,
+            self._jwt_verification_value(signing_key),
+            algorithms=[signing_key.algorithm],
+            audience=audience,
+            options=options,
+        )
+        return dict(verified)
+
+    def _jwt_signing_value(self, signing_key: TenantSigningKey):
+        if signing_key.shared_secret:
+            return signing_key.shared_secret
+        assert signing_key.private_key_pem, "No private key available for signing"
+        return signing_key.private_key_pem
+
+    def _jwt_verification_value(self, signing_key: TenantSigningKey):
+        if signing_key.shared_secret:
+            return signing_key.shared_secret
+        assert signing_key.public_key_pem, "No public key available for verification"
+        return signing_key.public_key_pem
+
+    # ------------------------------------------------------------------
+    # JWKS helpers
+    # ------------------------------------------------------------------
+    def build_jwks(self) -> Dict[str, object]:
+        keys = [key.as_public_jwk() for key in self._cache.values()]
+        filtered = [key for key in keys if key]
+        return {"keys": filtered}
+
+
+__all__ = ["TenantSigningKey", "TokenSigner"]


### PR DESCRIPTION
## Summary
- build a standalone FastAPI identity microservice with OAuth2/OIDC token flows, refresh support, introspection, SCIM provisioning, MFA hooks, and gRPC handlers
- define multi-tenant identity models with Alembic migrations and integrate per-tenant signing key retrieval via Vault/AWS compatible helpers
- provide service-to-service JWT validation utilities, documentation, and update the API gateway to call the new identity service and validate tokens via JWKS

## Testing
- pytest *(fails: missing optional dependencies `asgiref` and `pydantic_settings` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae923945c833085d4cb8f69b9a7be