### PR TITLE
Add tenant-aware orchestration and service documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ docker compose up -d \
 python -m crypto_bot.main status
 ```
 
+## 🧩 Tenant Configuration
+
+Multi-tenant deployments are described in `config/tenants.yaml`. The API
+gateway forwards the `X-Tenant-ID` header to downstream services so they can
+load tenant-specific strategy, risk, and execution settings. The market data,
+trading engine, and execution services expose tenant-aware health endpoints to
+surface per-tenant workloads.
+
 ## 🕸 Microservice API Gateway
 
 LegacyCoinTrader's microservice rollout is fronted by a FastAPI-powered API gateway

--- a/config/tenants.yaml
+++ b/config/tenants.yaml
@@ -1,0 +1,50 @@
+tenants:
+  alpha:
+    name: Alpha Quant Fund
+    redis_namespace: tenant:{tenant}
+    risk:
+      max_active_cycles: 2
+      risk_budget: 250000.0
+    execution:
+      network_segment: segment-alpha
+      failover_endpoints:
+        - https://alpha-primary.exchange.example
+        - https://alpha-secondary.exchange.example
+      credentials:
+        api_key:
+          source: env
+          name: ALPHA_EXCHANGE_KEY
+        api_secret:
+          source: env
+          name: ALPHA_EXCHANGE_SECRET
+        passphrase:
+          source: env
+          name: ALPHA_EXCHANGE_PASSPHRASE
+    config_overrides:
+      risk:
+        starting_balance: 250000.0
+      strategy:
+        default_profile: alpha-low-latency
+
+  beta:
+    name: Beta Digital Assets
+    redis_namespace: tenant:{tenant}
+    risk:
+      max_active_cycles: 1
+      risk_budget: 100000.0
+    execution:
+      network_segment: segment-beta
+      failover_endpoints:
+        - https://beta-edge.exchange.example
+      credentials:
+        api_key:
+          source: env
+          name: BETA_EXCHANGE_KEY
+        api_secret:
+          source: env
+          name: BETA_EXCHANGE_SECRET
+    config_overrides:
+      risk:
+        starting_balance: 100000.0
+      strategy:
+        default_profile: beta-swing

--- a/services/common/tenant.py
+++ b/services/common/tenant.py
@@ -1,0 +1,358 @@
+"""Shared tenant context utilities for multi-tenant services.
+
+This module provides a common registry and FastAPI middleware that extracts a
+tenant identifier from inbound requests, loads the associated configuration and
+risk policies, and exposes the resolved context to downstream service layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import yaml
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+from services.configuration.managed_config_service import deep_merge
+
+
+class TenantConfigurationError(RuntimeError):
+    """Raised when tenant configuration cannot be loaded or parsed."""
+
+
+class TenantNotFoundError(KeyError):
+    """Raised when the requested tenant does not exist in the registry."""
+
+
+class TenantLimitError(RuntimeError):
+    """Raised when a tenant level limit (cycles, risk budget, etc.) is exceeded."""
+
+
+@dataclass(frozen=True)
+class TenantRiskPolicy:
+    """Declarative risk controls configured for a tenant."""
+
+    max_active_cycles: int = 1
+    risk_budget: Optional[float] = None
+
+    def validate_cycle_start(self, active_cycles: int) -> None:
+        """Ensure the tenant has capacity for another active cycle."""
+
+        if self.max_active_cycles <= 0:
+            raise TenantLimitError("Tenant is not allowed to run trading cycles")
+        if active_cycles >= self.max_active_cycles:
+            raise TenantLimitError(
+                "Tenant has reached the maximum number of concurrent trading cycles"
+            )
+
+    def validate_allocation(self, allocation: Optional[float]) -> float:
+        """Validate a requested risk allocation, returning the normalised value."""
+
+        value = float(allocation or 0.0)
+        if value < 0:
+            raise TenantLimitError("Risk allocation cannot be negative")
+        if self.risk_budget is not None and value > self.risk_budget:
+            raise TenantLimitError(
+                "Requested risk allocation exceeds the tenant risk budget"
+            )
+        return value
+
+    def validate_additional_allocation(self, current: float, delta: float) -> float:
+        """Validate increasing an allocation by ``delta`` returning the new total."""
+
+        if delta < 0:
+            raise TenantLimitError("Risk allocation increment cannot be negative")
+        total = float(current) + float(delta)
+        if self.risk_budget is not None and total > self.risk_budget:
+            raise TenantLimitError(
+                "Risk budget exhausted for this tenant"
+            )
+        return total
+
+
+@dataclass(frozen=True)
+class TenantExecutionConfig:
+    """Execution specific overrides for a tenant."""
+
+    overrides: Mapping[str, Any] = field(default_factory=dict)
+    credentials: Mapping[str, Any] = field(default_factory=dict)
+    network_segment: Optional[str] = None
+    failover_endpoints: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TenantConfiguration:
+    """Materialised tenant configuration loaded from ``config/tenants.yaml``."""
+
+    tenant_id: str
+    name: str
+    redis_namespace: str
+    risk: TenantRiskPolicy
+    execution: TenantExecutionConfig
+    config_overrides: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class TenantContext:
+    """Lightweight accessor that exposes tenant metadata to services."""
+
+    __slots__ = {"_config"}
+
+    def __init__(self, config: TenantConfiguration) -> None:
+        self._config = config
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def tenant_id(self) -> str:
+        return self._config.tenant_id
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    @property
+    def risk_policy(self) -> TenantRiskPolicy:
+        return self._config.risk
+
+    @property
+    def execution_config(self) -> TenantExecutionConfig:
+        return self._config.execution
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def redis_namespace(self, namespace: Optional[str] = None) -> str:
+        """Return a namespaced Redis prefix for the tenant."""
+
+        base = self._config.redis_namespace.format(tenant=self.tenant_id)
+        if namespace:
+            return f"{base}:{namespace}"
+        return base
+
+    def redis_key(self, *parts: str) -> str:
+        """Compose a fully qualified Redis key scoped to the tenant."""
+
+        segments = [self.redis_namespace()]
+        segments.extend(part for part in parts if part)
+        return ":".join(segments)
+
+    def channel(self, base: str) -> str:
+        """Return a tenant-scoped pub/sub channel name."""
+
+        channel = base.rstrip(":")
+        return f"{channel}:{self.tenant_id}"
+
+    def apply_config(self, base_config: Mapping[str, Any]) -> Dict[str, Any]:
+        """Merge tenant overrides with a base configuration mapping."""
+
+        merged = deep_merge(dict(base_config), dict(self._config.config_overrides))
+        merged.setdefault("tenant", {})
+        if isinstance(merged["tenant"], Mapping):
+            merged["tenant"] = dict(merged["tenant"])
+            merged["tenant"].setdefault("id", self.tenant_id)
+            merged["tenant"].setdefault("name", self.name)
+        return merged
+
+    def execution_overrides(self, config: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+        """Merge execution overrides and credentials with a request config."""
+
+        merged = deep_merge(dict(config or {}), dict(self.execution_config.overrides))
+        if self.execution_config.credentials:
+            merged.setdefault("credentials", {})
+            merged["credentials"] = deep_merge(
+                dict(merged["credentials"]), dict(self.execution_config.credentials)
+            )
+        if self.execution_config.network_segment:
+            merged.setdefault("network_segment", self.execution_config.network_segment)
+        if self.execution_config.failover_endpoints:
+            merged.setdefault(
+                "failover_endpoints", list(self.execution_config.failover_endpoints)
+            )
+        merged.setdefault("tenant_id", self.tenant_id)
+        return merged
+
+    def enrich_metadata(
+        self, metadata: Optional[Mapping[str, Any]], *, base: Optional[Mapping[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Merge tenant details into metadata dictionaries."""
+
+        merged: Dict[str, Any] = dict(base or {})
+        if metadata:
+            merged.update(dict(metadata))
+        merged.setdefault("tenant_id", self.tenant_id)
+        merged.setdefault("tenant", {"id": self.tenant_id, "name": self.name})
+        return merged
+
+
+class TenantRegistry:
+    """In-memory registry of tenant configurations backed by YAML."""
+
+    def __init__(self, *, path: Path | str | None = None) -> None:
+        manifest_path = Path(path) if path else DEFAULT_TENANT_CONFIG_PATH
+        if not manifest_path.exists():
+            raise TenantConfigurationError(
+                f"Tenant configuration file not found: {manifest_path}"
+            )
+        try:
+            raw = yaml.safe_load(manifest_path.read_text()) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - configuration error
+            raise TenantConfigurationError(str(exc)) from exc
+        tenants_data = raw.get("tenants", {}) if isinstance(raw, Mapping) else {}
+        if not isinstance(tenants_data, Mapping):
+            raise TenantConfigurationError("Tenant configuration must contain a mapping")
+        self._configs: Dict[str, TenantConfiguration] = {}
+        for tenant_id, payload in tenants_data.items():
+            if not isinstance(payload, Mapping):
+                continue
+            config = self._parse_tenant(str(tenant_id), payload)
+            self._configs[config.tenant_id] = config
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _parse_tenant(
+        self, tenant_id: str, data: Mapping[str, Any]
+    ) -> TenantConfiguration:
+        name = str(data.get("name", tenant_id))
+        namespace_template = str(data.get("redis_namespace", "tenant:{tenant}"))
+        risk_cfg = data.get("risk", {}) or {}
+        risk_policy = TenantRiskPolicy(
+            max_active_cycles=int(risk_cfg.get("max_active_cycles", 1)),
+            risk_budget=(
+                float(risk_cfg["risk_budget"])
+                if risk_cfg.get("risk_budget") is not None
+                else None
+            ),
+        )
+        execution_cfg = data.get("execution", {}) or {}
+        exec_config = TenantExecutionConfig(
+            overrides=dict(execution_cfg.get("overrides", {})),
+            credentials=dict(execution_cfg.get("credentials", {})),
+            network_segment=execution_cfg.get("network_segment"),
+            failover_endpoints=tuple(execution_cfg.get("failover_endpoints", []) or ()),
+        )
+        config_overrides = dict(data.get("config_overrides", data.get("config", {})) or {})
+        metadata = dict(data.get("metadata", {}))
+        return TenantConfiguration(
+            tenant_id=tenant_id,
+            name=name,
+            redis_namespace=namespace_template,
+            risk=risk_policy,
+            execution=exec_config,
+            config_overrides=config_overrides,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def tenants(self) -> Iterable[TenantConfiguration]:
+        return tuple(self._configs.values())
+
+    def get(self, tenant_id: str) -> TenantContext:
+        try:
+            config = self._configs[tenant_id]
+        except KeyError as exc:
+            raise TenantNotFoundError(tenant_id) from exc
+        return TenantContext(config)
+
+
+DEFAULT_TENANT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "tenants.yaml"
+)
+
+
+@lru_cache
+def get_tenant_registry() -> TenantRegistry:
+    """Return a cached tenant registry instance."""
+
+    return TenantRegistry()
+
+
+class TenantContextMiddleware(BaseHTTPMiddleware):
+    """Middleware that attaches a :class:`TenantContext` to each request."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        header_name: str = "x-tenant-id",
+        registry: TenantRegistry | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._header_name = header_name.lower()
+        self._registry = registry or get_tenant_registry()
+
+    async def dispatch(self, request: Request, call_next):
+        tenant_id = self._extract_tenant_id(request)
+        if not tenant_id:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "Missing tenant identifier in request headers"},
+            )
+        try:
+            context = self._registry.get(tenant_id)
+        except TenantNotFoundError:
+            return JSONResponse(
+                status_code=404,
+                content={"detail": f"Unknown tenant '{tenant_id}'"},
+            )
+        request.state.tenant_context = context
+        return await call_next(request)
+
+    def _extract_tenant_id(self, request: Request) -> Optional[str]:
+        header_value = request.headers.get(self._header_name)
+        if header_value:
+            return header_value.strip()
+        # Support canonical header casing (X-Tenant-ID)
+        alt_value = request.headers.get("X-Tenant-ID")
+        if alt_value:
+            return alt_value.strip()
+        # Allow query parameter fallback for non-HTTP transports (e.g. WebSockets)
+        query_value = request.query_params.get("tenant_id")
+        if query_value:
+            return query_value.strip()
+        return None
+
+
+def get_tenant_context(request: Request) -> TenantContext:
+    """FastAPI dependency that returns the tenant context for a request."""
+
+    context: TenantContext | None = getattr(request.state, "tenant_context", None)
+    if context is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Tenant context is not available for this request",
+        )
+    return context
+
+
+class TenantContextClient:
+    """Utility for background jobs to resolve :class:`TenantContext` instances."""
+
+    def __init__(self, registry: TenantRegistry | None = None) -> None:
+        self._registry = registry or get_tenant_registry()
+
+    def get(self, tenant_id: str) -> TenantContext:
+        return self._registry.get(tenant_id)
+
+
+__all__ = [
+    "TenantConfigurationError",
+    "TenantContext",
+    "TenantContextClient",
+    "TenantContextMiddleware",
+    "TenantLimitError",
+    "TenantNotFoundError",
+    "TenantRegistry",
+    "TenantRiskPolicy",
+    "get_tenant_context",
+    "get_tenant_registry",
+]
+

--- a/services/execution/README.md
+++ b/services/execution/README.md
@@ -1,0 +1,18 @@
+# Execution Service
+
+Every request to the execution API must include an `X-Tenant-ID` header. The
+service derives exchange credentials, network segments, and failover routes
+from `config/tenants.yaml` and keeps HTTP/WebSocket sessions isolated per
+tenant.
+
+## Tenant-specific behaviour
+
+* `POST /exchanges` and `POST /orders` merge tenant execution overrides and
+  load dedicated API credentials before opening sessions.
+* Order lifecycle events (`/orders/{id}/events`) and the internal caches are
+  keyed by `tenant_id:client_order_id` to prevent cross-tenant leakage.
+* `GET /health/tenant` reports the number of cached exchange sessions and open
+  orders for the tenant making the request.
+
+Requests that omit the tenant header are rejected with `400`. Include the
+header on every call when interacting with the execution service.

--- a/services/market_data/README.md
+++ b/services/market_data/README.md
@@ -1,0 +1,27 @@
+# Market Data Service
+
+The market data microservice now enforces tenant isolation. All client calls
+must include an `X-Tenant-ID` header so the service can load the appropriate
+configuration from `config/tenants.yaml`.
+
+## Tenant-aware behaviour
+
+* Redis caches and pub/sub channels are automatically namespaced per tenant.
+  Keys follow the pattern `tenant:{id}:{namespace}:...` and channels are
+  suffixed with the tenant identifier.
+* The following endpoints are tenant-scoped and require the header:
+  * `POST /symbols/load`
+  * `POST /ohlcv/update`
+  * `POST /ohlcv/multi`
+  * `POST /regime/update`
+  * `POST /order-book/snapshot`
+* WebSocket subscriptions to `/ws/ohlcv` also require the tenant identifier
+  (header or `tenant_id` query parameter).
+
+## Health and observability
+
+* `GET /health` retains the global status check.
+* `GET /health/tenant` reports per-tenant cache counts (`ohlcv`, `regime`,
+  `order-book`, and `symbols`).
+
+Include the tenant header on every request when integrating with this service.

--- a/services/market_data/redis_cache.py
+++ b/services/market_data/redis_cache.py
@@ -21,15 +21,15 @@ def _safe_exchange(exchange_id: str) -> str:
 
 
 def _cache_key(namespace: str, exchange_id: str, timeframe: str, symbol: str) -> str:
-    return f"market-data:{namespace}:{_safe_exchange(exchange_id)}:{timeframe}:{_safe_symbol(symbol)}"
+    return f"{namespace}:{_safe_exchange(exchange_id)}:{timeframe}:{_safe_symbol(symbol)}"
 
 
-def _order_book_key(exchange_id: str, symbol: str) -> str:
-    return f"market-data:order-book:{_safe_exchange(exchange_id)}:{_safe_symbol(symbol)}"
+def _order_book_key(namespace: str, exchange_id: str, symbol: str) -> str:
+    return f"{namespace}:{_safe_exchange(exchange_id)}:{_safe_symbol(symbol)}"
 
 
-def _symbols_key(exchange_id: str) -> str:
-    return f"market-data:symbols:{_safe_exchange(exchange_id)}"
+def _symbols_key(namespace: str, exchange_id: str) -> str:
+    return f"{namespace}:{_safe_exchange(exchange_id)}"
 
 
 def _candles_to_dataframe(candles: Iterable[Iterable[float]]) -> pd.DataFrame:
@@ -155,12 +155,13 @@ async def store_multi_timeframe_cache(
 
 async def store_order_book(
     redis_client: Redis,
+    namespace: str,
     exchange_id: str,
     symbol: str,
     order_book: Mapping[str, object],
     ttl: int,
 ) -> None:
-    key = _order_book_key(exchange_id, symbol)
+    key = _order_book_key(namespace, exchange_id, symbol)
     payload = {
         "exchange": exchange_id,
         "symbol": symbol,
@@ -174,11 +175,12 @@ async def store_order_book(
 
 async def store_symbols(
     redis_client: Redis,
+    namespace: str,
     exchange_id: str,
     symbols: Iterable[str],
     ttl: int,
 ) -> None:
-    key = _symbols_key(exchange_id)
+    key = _symbols_key(namespace, exchange_id)
     payload = {
         "exchange": exchange_id,
         "symbols": list(symbols),

--- a/services/trading_engine/README.md
+++ b/services/trading_engine/README.md
@@ -1,0 +1,17 @@
+# Trading Engine Service
+
+All REST calls to the trading engine must include an `X-Tenant-ID` header. The
+service loads tenant-specific strategy, risk, and execution settings from
+`config/tenants.yaml` and runs trading cycles independently for each tenant.
+
+## Tenant-aware scheduling
+
+* Cycle state is stored in Redis under per-tenant keys (`tenant:{id}:...`).
+* `POST /cycles/start` accepts an optional `risk_allocation` field and enforces
+  the tenant's `max_active_cycles` and risk budget before scheduling.
+* `POST /cycles/run` applies the same budget checks for ad-hoc cycles.
+* `GET /cycles/status` and `GET /health/tenant` return the current state for
+  the tenant identified by the header.
+
+The scheduler emits `tenant_id` in cycle metadata so downstream systems can
+attribute work and enforce limits.

--- a/services/trading_engine/app.py
+++ b/services/trading_engine/app.py
@@ -12,6 +12,13 @@ import redis.asyncio as redis
 
 from libs.bootstrap import load_config
 
+from services.common.tenant import (
+    TenantContext,
+    TenantContextMiddleware,
+    TenantLimitError,
+    get_tenant_context,
+)
+
 from services.monitoring.config import get_monitoring_settings
 from services.monitoring.logging import configure_logging
 from services.monitoring.instrumentation import instrument_fastapi_app
@@ -59,32 +66,36 @@ async def lifespan(app: FastAPI):
     state_store = RedisCycleStateStore(redis_client, key_prefix=settings.state_key_prefix)
     await state_store.ensure_defaults(settings.default_cycle_interval)
 
-    config = load_config()
-    services = build_service_container()
+    base_config = load_config()
 
-    risk_manager = build_risk_client(config.get("risk", {}))
-    paper_wallet = build_paper_wallet_client(config)
-    position_guard = build_position_guard_client(config)
-
-    trade_manager = None
-    portfolio_service = getattr(services, "portfolio", None)
-    if portfolio_service is not None:
-        try:
-            trade_manager = portfolio_service.get_trade_manager()
-        except Exception:  # pragma: no cover - defensive
-            logger.warning("Trade manager initialisation failed", exc_info=True)
-
-    interface = TradingEngineInterface(
-        services=services,
-        config=config,
-        risk_client=risk_manager,
-        paper_wallet=paper_wallet,
-        position_guard=position_guard,
-        trade_manager=trade_manager,
-    )
+    def build_interface_for_tenant(tenant: TenantContext) -> TradingEngineInterface:
+        tenant_config = tenant.apply_config(base_config)
+        services = build_service_container()
+        risk_manager = build_risk_client(tenant_config.get("risk", {}))
+        paper_wallet = build_paper_wallet_client(tenant_config)
+        position_guard = build_position_guard_client(tenant_config)
+        trade_manager = None
+        portfolio_service = getattr(services, "portfolio", None)
+        if portfolio_service is not None:
+            try:
+                trade_manager = portfolio_service.get_trade_manager()
+            except Exception:  # pragma: no cover - defensive
+                logger.warning(
+                    "Trade manager initialisation failed for tenant %s",
+                    tenant.tenant_id,
+                    exc_info=True,
+                )
+        return TradingEngineInterface(
+            services=services,
+            config=tenant_config,
+            risk_client=risk_manager,
+            paper_wallet=paper_wallet,
+            position_guard=position_guard,
+            trade_manager=trade_manager,
+        )
 
     scheduler = CycleScheduler(
-        interface=interface,
+        interface_factory=build_interface_for_tenant,
         state_store=state_store,
         default_interval=settings.default_cycle_interval,
     )
@@ -92,14 +103,12 @@ async def lifespan(app: FastAPI):
     app.state.redis = redis_client
     app.state.scheduler = scheduler
     app.state.settings = settings
-    app.state.trading_interface = interface
-    app.state.service_container = services
+    app.state.base_config = base_config
 
     try:
         yield
     finally:
         await scheduler.shutdown()
-        await interface.shutdown()
         await redis_client.close()
 
 
@@ -119,6 +128,7 @@ def get_settings_dependency(request: Request) -> Settings:
 
 app = FastAPI(title="Trading Engine", lifespan=lifespan)
 instrument_fastapi_app(app, settings=monitoring_settings)
+app.add_middleware(TenantContextMiddleware)
 
 
 @app.get("/health")
@@ -126,6 +136,15 @@ async def health() -> Dict[str, str]:
     """Basic health endpoint."""
 
     return {"status": "ok"}
+
+
+@app.get("/health/tenant", response_model=CycleStateResponse)
+async def tenant_health(
+    scheduler: CycleScheduler = Depends(get_scheduler),
+    tenant: TenantContext = Depends(get_tenant_context),
+) -> CycleStateResponse:
+    state = await scheduler.get_state(tenant)
+    return CycleStateResponse.from_state(state)
 
 
 @app.get("/readiness")
@@ -146,24 +165,39 @@ async def readiness(request: Request, settings: Settings = Depends(get_settings_
 async def start_cycle(
     payload: StartCycleRequest,
     scheduler: CycleScheduler = Depends(get_scheduler),
+    tenant: TenantContext = Depends(get_tenant_context),
 ) -> CycleStateResponse:
-    state = await scheduler.start(
-        interval_seconds=payload.interval_seconds,
-        immediate=payload.immediate,
-        metadata=payload.metadata,
-    )
+    try:
+        state = await scheduler.start(
+            tenant,
+            interval_seconds=payload.interval_seconds,
+            immediate=payload.immediate,
+            metadata=payload.metadata,
+            risk_allocation=payload.risk_allocation,
+        )
+    except TenantLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
     return CycleStateResponse.from_state(state)
 
 
 @app.post("/cycles/stop", response_model=CycleStateResponse)
-async def stop_cycle(scheduler: CycleScheduler = Depends(get_scheduler)) -> CycleStateResponse:
-    state = await scheduler.stop()
+async def stop_cycle(
+    scheduler: CycleScheduler = Depends(get_scheduler),
+    tenant: TenantContext = Depends(get_tenant_context),
+) -> CycleStateResponse:
+    state = await scheduler.stop(tenant)
     return CycleStateResponse.from_state(state)
 
 
 @app.get("/cycles/status", response_model=CycleStateResponse)
-async def cycle_status(scheduler: CycleScheduler = Depends(get_scheduler)) -> CycleStateResponse:
-    state = await scheduler.get_state()
+async def cycle_status(
+    scheduler: CycleScheduler = Depends(get_scheduler),
+    tenant: TenantContext = Depends(get_tenant_context),
+) -> CycleStateResponse:
+    state = await scheduler.get_state(tenant)
     return CycleStateResponse.from_state(state)
 
 
@@ -171,9 +205,21 @@ async def cycle_status(scheduler: CycleScheduler = Depends(get_scheduler)) -> Cy
 async def run_cycle(
     scheduler: CycleScheduler = Depends(get_scheduler),
     payload: StartCycleRequest | None = None,
+    tenant: TenantContext = Depends(get_tenant_context),
 ) -> RunCycleResponse:
     metadata = dict(payload.metadata if payload else {})
-    result = await scheduler.run_once(metadata=metadata)
+    risk_allocation = payload.risk_allocation if payload else None
+    try:
+        result = await scheduler.run_once(
+            tenant,
+            metadata=metadata,
+            risk_allocation=risk_allocation,
+        )
+    except TenantLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
     started_at = result.started_at or datetime.now(timezone.utc)
     completed_at = result.completed_at or datetime.now(timezone.utc)
     merged_metadata = {**metadata, **result.metadata}

--- a/services/trading_engine/scheduler.py
+++ b/services/trading_engine/scheduler.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional, cast
 
+from services.common.tenant import TenantContext, TenantLimitError
 from services.interface_layer.cycle import CycleExecutionResult
 
 from .interface import TradingEngineInterface
@@ -16,105 +18,202 @@ from .redis_state import CycleState, RedisCycleStateStore
 logger = logging.getLogger(__name__)
 
 
-class CycleScheduler:
-    """Manage periodic execution of trading cycles."""
+class _TenantSchedule:
+    __slots__ = ("interface", "state_store", "interval", "task", "running", "lock")
 
     def __init__(
         self,
         interface: TradingEngineInterface,
         state_store: RedisCycleStateStore,
+        interval: int,
+    ) -> None:
+        self.interface = interface
+        self.state_store = state_store
+        self.interval = max(interval, 1)
+        self.task: Optional[asyncio.Task[Any]] = None
+        self.running = False
+        self.lock = asyncio.Lock()
+
+
+class CycleScheduler:
+    """Manage periodic execution of trading cycles on a per-tenant basis."""
+
+    def __init__(
+        self,
+        interface_factory: Callable[
+            [TenantContext], TradingEngineInterface | Awaitable[TradingEngineInterface]
+        ],
+        state_store: RedisCycleStateStore,
         default_interval: int,
     ) -> None:
-        self._interface = interface
+        self._interface_factory = interface_factory
         self._state_store = state_store
-        self._interval = max(default_interval, 1)
-        self._task: Optional[asyncio.Task] = None
-        self._running = False
-        self._lock = asyncio.Lock()
+        self._default_interval = max(default_interval, 1)
+        self._tenants: Dict[str, _TenantSchedule] = {}
+
+    async def _build_interface(self, tenant: TenantContext) -> TradingEngineInterface:
+        candidate = self._interface_factory(tenant)
+        if inspect.isawaitable(candidate):
+            candidate = await candidate  # type: ignore[assignment]
+        return cast(TradingEngineInterface, candidate)
+
+    async def _ensure_schedule(self, tenant: TenantContext) -> _TenantSchedule:
+        schedule = self._tenants.get(tenant.tenant_id)
+        if schedule is None:
+            interface = await self._build_interface(tenant)
+            store = self._state_store.for_tenant(tenant.tenant_id)
+            await store.ensure_defaults(self._default_interval)
+            schedule = _TenantSchedule(interface, store, self._default_interval)
+            self._tenants[tenant.tenant_id] = schedule
+        return schedule
 
     async def start(
         self,
+        tenant: TenantContext,
+        *,
         interval_seconds: Optional[int] = None,
         immediate: bool = False,
         metadata: Optional[Dict[str, Any]] = None,
+        risk_allocation: Optional[float] = None,
     ) -> CycleState:
-        async with self._lock:
-            interval = int(interval_seconds or self._interval)
-            self._interval = max(interval, 1)
-
-            state = await self._state_store.load_state()
+        schedule = await self._ensure_schedule(tenant)
+        async with schedule.lock:
+            active_cycles = 1 if schedule.running else 0
+            tenant.risk_policy.validate_cycle_start(active_cycles)
+            schedule.interval = max(
+                int(interval_seconds or schedule.interval or self._default_interval), 1
+            )
+            state = await schedule.state_store.load_state()
             state.running = True
-            state.interval_seconds = self._interval
-            state.metadata = dict(metadata or {})
+            state.interval_seconds = schedule.interval
+            state.metadata = tenant.enrich_metadata(metadata)
+            allocation_value = tenant.risk_policy.validate_allocation(risk_allocation)
+            state.metadata["risk_allocation"] = allocation_value
+            state.tenant_id = tenant.tenant_id
             now = datetime.now(timezone.utc)
             state.next_run_at = now if immediate else state.predict_next_run() or now
-            await self._state_store.save_state(state)
-
-            self._running = True
-            if self._task and not self._task.done():
-                self._task.cancel()
+            await schedule.state_store.save_state(state)
+            schedule.running = True
+            if schedule.task and not schedule.task.done():
+                schedule.task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await self._task
-            self._task = asyncio.create_task(self._run_loop(immediate))
-            logger.info("Trading cycle scheduler started with interval %s", self._interval)
-            return state
+                    await schedule.task
+            schedule.task = asyncio.create_task(self._run_loop(tenant, schedule))
+        if immediate:
+            await self._execute_cycle(schedule, tenant, dict(state.metadata))
+        logger.info(
+            "Trading cycle scheduler started for tenant %s with interval %s",
+            tenant.tenant_id,
+            schedule.interval,
+        )
+        return await schedule.state_store.load_state()
 
-    async def stop(self) -> CycleState:
-        async with self._lock:
-            self._running = False
-            if self._task:
-                self._task.cancel()
+    async def stop(self, tenant: TenantContext) -> CycleState:
+        schedule = await self._ensure_schedule(tenant)
+        async with schedule.lock:
+            schedule.running = False
+            if schedule.task:
+                schedule.task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await self._task
-                self._task = None
-            state = await self._state_store.update(running=False, next_run_at=None)
-            logger.info("Trading cycle scheduler stopped")
-            return state
+                    await schedule.task
+                schedule.task = None
+            state = await schedule.state_store.load_state()
+            state.running = False
+            state.next_run_at = None
+            state.metadata = tenant.enrich_metadata({}, base=state.metadata)
+            state.metadata["risk_allocation"] = 0.0
+            state.tenant_id = tenant.tenant_id
+            await schedule.state_store.save_state(state)
+        logger.info("Trading cycle scheduler stopped for tenant %s", tenant.tenant_id)
+        return await schedule.state_store.load_state()
 
-    async def run_once(self, metadata: Optional[Dict[str, Any]] = None) -> CycleExecutionResult:
-        metadata = dict(metadata or {})
+    async def run_once(
+        self,
+        tenant: TenantContext,
+        metadata: Optional[Dict[str, Any]] = None,
+        risk_allocation: Optional[float] = None,
+    ) -> CycleExecutionResult:
+        schedule = await self._ensure_schedule(tenant)
+        async with schedule.lock:
+            state = await schedule.state_store.load_state()
+            current_allocation = float(state.metadata.get("risk_allocation", 0.0) or 0.0)
+            additional = float(risk_allocation or 0.0)
+            total_allocation = tenant.risk_policy.validate_additional_allocation(
+                current_allocation, additional
+            )
+            merged_metadata = tenant.enrich_metadata(metadata, base=state.metadata)
+            merged_metadata["risk_allocation"] = total_allocation
+            state.metadata = merged_metadata
+            state.tenant_id = tenant.tenant_id
+            await schedule.state_store.save_state(state)
+            metadata_payload = dict(state.metadata)
+        return await self._execute_cycle(schedule, tenant, metadata_payload)
+
+    async def get_state(self, tenant: TenantContext) -> CycleState:
+        schedule = self._tenants.get(tenant.tenant_id)
+        if schedule is not None:
+            return await schedule.state_store.load_state()
+        store = self._state_store.for_tenant(tenant.tenant_id)
+        return await store.load_state()
+
+    async def shutdown(self) -> None:
+        schedules = list(self._tenants.items())
+        self._tenants.clear()
+        for tenant_id, schedule in schedules:
+            schedule.running = False
+            if schedule.task:
+                schedule.task.cancel()
+            if schedule.task:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await schedule.task
+            try:
+                await schedule.interface.shutdown()
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.debug("Failed to shut down interface for tenant %s", tenant_id, exc_info=True)
+
+    async def _execute_cycle(
+        self,
+        schedule: _TenantSchedule,
+        tenant: TenantContext,
+        metadata: Dict[str, Any],
+    ) -> CycleExecutionResult:
         started_at = datetime.now(timezone.utc)
-        await self._state_store.mark_cycle_start(started_at)
+        await schedule.state_store.mark_cycle_start(started_at)
         try:
-            result = await self._interface.run_cycle(metadata=metadata)
+            result = await schedule.interface.run_cycle(metadata=metadata)
+        except TenantLimitError:
+            raise
         except Exception as exc:  # pragma: no cover - defensive logging
-            logger.exception("Trading cycle execution failed")
-            await self._state_store.mark_cycle_failure(
+            logger.exception("Trading cycle execution failed for tenant %s", tenant.tenant_id)
+            await schedule.state_store.mark_cycle_failure(
                 str(exc), datetime.now(timezone.utc), metadata=metadata
             )
             raise
         completed_at = result.completed_at or datetime.now(timezone.utc)
-        state = await self._state_store.mark_cycle_complete(
+        state = await schedule.state_store.mark_cycle_complete(
             result, completed_at, metadata=metadata
         )
-        if state.running:
-            await self._state_store.update(next_run_at=state.predict_next_run())
+        if schedule.running:
+            await schedule.state_store.update(next_run_at=state.predict_next_run())
         return result
 
-    async def get_state(self) -> CycleState:
-        return await self._state_store.load_state()
-
-    async def shutdown(self) -> None:
+    async def _run_loop(self, tenant: TenantContext, schedule: _TenantSchedule) -> None:
         try:
-            await self.stop()
-        finally:
-            self._task = None
-
-    async def _run_loop(self, immediate: bool) -> None:
-        try:
-            if immediate:
-                await self.run_once()
-            while self._running:
-                await asyncio.sleep(self._interval)
-                if not self._running:
+            while schedule.running:
+                await asyncio.sleep(schedule.interval)
+                if not schedule.running:
                     break
-                await self.run_once()
+                state = await schedule.state_store.load_state()
+                metadata = tenant.enrich_metadata({}, base=state.metadata)
+                await self._execute_cycle(schedule, tenant, metadata)
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # pragma: no cover - background loop safety
-            logger.exception("Trading cycle loop crashed: %s", exc)
+            logger.exception(
+                "Trading cycle loop crashed for tenant %s: %s", tenant.tenant_id, exc
+            )
         finally:
-            self._task = None
+            schedule.task = None
 
 
 __all__ = ["CycleScheduler"]

--- a/services/trading_engine/schemas.py
+++ b/services/trading_engine/schemas.py
@@ -14,6 +14,7 @@ class StartCycleRequest(BaseModel):
     interval_seconds: Optional[int] = Field(default=None, ge=1)
     immediate: bool = Field(default=False)
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    risk_allocation: Optional[float] = Field(default=None, ge=0.0)
 
 
 class RunCycleResponse(BaseModel):
@@ -34,6 +35,7 @@ class CycleStateResponse(BaseModel):
     last_timings: Dict[str, float] = Field(default_factory=dict)
     last_error: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    tenant_id: Optional[str] = None
 
     @classmethod
     def from_state(cls, state: CycleState) -> "CycleStateResponse":
@@ -46,6 +48,7 @@ class CycleStateResponse(BaseModel):
             last_timings=state.last_timings,
             last_error=state.last_error,
             metadata=state.metadata,
+            tenant_id=state.tenant_id,
         )
 
 


### PR DESCRIPTION
## Summary
- add config/tenants.yaml and a shared tenant context middleware to drive per-tenant configuration
- scope market data caches, trading engine scheduler state, and execution sessions to tenant IDs and expose tenant health endpoints
- document the updated contracts for the market data, trading engine, and execution services

## Testing
- pytest *(fails: missing optional dependencies asgiref and pydantic_settings in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae92d19908330b9df3bdd2ee82d39