### PR TITLE
Add tenant-aware SLO monitoring and synthetic guardrails

### DIFF
--- a/services/monitoring/DASHBOARDS.md
+++ b/services/monitoring/DASHBOARDS.md
@@ -103,6 +103,34 @@ Panels:
 * **Authentication failures** – Alert if more than 25 login failures occur in
   ten minutes (monitor `status=401` for `/login`).
 
+## 5. Tenant SLO & Synthetic Overview
+
+**Purpose**: provide an at-a-glance view of tenant health, synthetic guard-rails
+and compliance posture for the on-call engineer.
+
+| Panel | Query | Notes |
+|-------|-------|-------|
+| Latency p95 per tenant | `legacycoin_tenant_latency_p95_seconds` | Display as seconds and colour by `tenant`/`service_role`. Threshold at 0.5 seconds. |
+| Error rate per tenant | `legacycoin_tenant_error_rate` | Overlay the 1% error budget as a reference line. |
+| Throughput per tenant | `legacycoin_tenant_throughput_rps` | Highlight drops below 1&nbsp;rps. |
+| Synthetic status | `legacycoin_synthetic_check_status` | Show as a table with `check`, `tenant` and `service_role`. Values of 0 indicate failures or breaches. |
+| Synthetic RTO/RPO | `legacycoin_synthetic_check_recovery_time_seconds` / `legacycoin_synthetic_check_data_lag_seconds` | Compare against the 900&nbsp;s RTO and 300&nbsp;s RPO targets. |
+| Secrets rotation age | `legacycoin_compliance_secrets_rotation_age_days` | Visualise days since rotation; annotate at the 90-day limit. |
+
+### Alerts
+
+The new Alertmanager rules in [`alerts.yaml`](./alerts.yaml) back these panels:
+
+* **TenantLatencySLOViolation**, **TenantErrorRateSLOViolation** and
+  **TenantThroughputRegression** – escalate when the golden signals drift for a
+  specific tenant/service role.
+* **SyntheticCheckFailure**, **SyntheticRecoveryTimeBreach** and
+  **SyntheticDataLagBreach** – guard RTO/RPO objectives driven by the synthetic
+  endpoints. These alerts reference the SOC2-aligned runbooks documented in the
+  README.
+* **SecretsRotationStale** – notifies the compliance officer when the
+  `SECRETS_ROTATED_AT` timestamp exceeds the allowed age.
+
 ## Implementation notes
 
 * All dashboards expect the Prometheus scrape config in

--- a/services/monitoring/README.md
+++ b/services/monitoring/README.md
@@ -10,6 +10,10 @@ imported by any service that needs consistent observability features.
 * **Prometheus Exporters** – `HttpMetrics` keeps per-service request counters and
   histograms. The middleware automatically exposes a `/metrics` endpoint that
   can be scraped by Prometheus or Grafana Agent.
+* **Tenant & Service Role Context** – Every log line, metric and span is tagged
+  with the active tenant and service role. The middleware reads the
+  `X-Tenant-ID` and `X-Service-Role` headers (configurable) and falls back to the
+  defaults supplied via `MonitoringSettings`.
 * **Correlation IDs** – Every inbound request reuses
   `crypto_bot.utils.logger`'s correlation ID helpers. The middleware injects the
   ID into logs, responses and OpenTelemetry spans, allowing cross-service trace
@@ -20,6 +24,72 @@ imported by any service that needs consistent observability features.
   stdout if the cluster is unreachable.
 * **Distributed Tracing** – `configure_tracing` configures an OTLP exporter for
   the service and registers a span processor with an OpenTelemetry collector.
+* **Tenant SLOs & Synthetic Checks** – Rolling latency, error rate and
+  throughput SLOs are calculated per tenant/service role. Synthetic guard-rail
+  endpoints report RTO/RPO compliance, feeding Alertmanager and Grafana panels.
+* **Compliance Metrics** – The `SECRETS_ROTATED_AT` timestamp is exported as
+  Prometheus gauges (`legacycoin_compliance_secrets_rotation_*`) to satisfy
+  audit retention controls.
+
+### Tenant-aware context propagation
+
+`MonitoringSettings` now includes `tenant_header`, `service_role_header`,
+`default_tenant` and `service_role`. These values drive both the logging
+formatter and the middleware. The helper functions in
+`crypto_bot.utils.logger`—`set_observability_context`,
+`get_tenant_id`/`get_service_role` and `clear_observability_context`—can be used
+outside HTTP handlers (e.g. background jobs) to ensure consistent tagging.
+
+### SLO and synthetic observability endpoints
+
+Both FastAPI and Flask integrations expose a REST surface for on-call teams:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/observability/slo` | GET | Return the rolling SLO snapshots for every tenant/service role. |
+| `/observability/slo/{tenant}` | GET | Return the snapshot for a specific tenant (optionally filter via `service_role`). |
+| `/observability/synthetic-checks` | GET/POST | List synthetic check statuses or push new results from synthetic monitors. |
+| `/observability/synthetic-checks/{name}` | GET | Fetch the latest status for a particular synthetic probe. |
+
+All responses include SLO targets, current measurements and compliance flags so
+operators can make rapid decisions during incidents. Synthetic check submissions
+accept latency, recovery time (RTO) and data lag (RPO) inputs and propagate them
+to Prometheus gauges.
+
+### Compliance telemetry
+
+`HttpMetrics` loads the `SECRETS_ROTATED_AT` environment variable (or
+`MonitoringSettings.compliance.fallback_timestamp`) and publishes:
+
+* `legacycoin_compliance_secrets_rotation_timestamp_seconds`
+* `legacycoin_compliance_secrets_rotation_age_days`
+
+Labels include the tenant/service role context so stale rotations can be tied to
+the appropriate customer partition. These metrics back the
+`SecretsRotationStale` alert in [`alerts.yaml`](./alerts.yaml).
+
+### Operational runbooks (SOC2 aligned)
+
+The observability package now documents the operational controls required for
+SOC2 readiness:
+
+1. **Initial triage** – When `TenantLatencySLOViolation` or
+   `TenantErrorRateSLOViolation` fires, inspect the `/observability/slo`
+   endpoint to confirm the breach window. Correlate with Jaeger using
+   `legacy.tenant_id` and `legacy.service_role`.
+2. **Synthetic guard-rails** – If `SyntheticCheckFailure`, `SyntheticRecoveryTimeBreach`
+   or `SyntheticDataLagBreach` triggers, query
+   `/observability/synthetic-checks/{name}` for detailed payloads. Compare the
+   values against the documented RTO (15&nbsp;minutes) and RPO (5&nbsp;minutes) and
+   begin the disaster recovery playbook if either threshold is exceeded.
+3. **Secrets rotation** – On `SecretsRotationStale`, rotate credentials,
+   update `SECRETS_ROTATED_AT` and attach the evidence to the compliance ticket.
+4. **Escalation** – Page the incident commander after 15 minutes of sustained
+   SLO violation or any synthetic check indicating a hard failure. Notify the
+   compliance officer within one business day for secrets rotation breaches.
+
+The same checklist is referenced by the new Alertmanager annotations so on-call
+staff can follow a consistent SOC2-compliant response.
 
 ## Usage
 
@@ -47,11 +117,23 @@ All settings can be tuned via environment variables. Nested configuration uses
 | Service identifier             | `MONITORING_SERVICE_NAME`               | `legacycoin-service`     |
 | Deployment environment         | `MONITORING_ENVIRONMENT`                | `development`            |
 | Correlation header name        | `MONITORING_CORRELATION_HEADER`         | `X-Correlation-ID`       |
+| Tenant header name             | `MONITORING_TENANT_HEADER`              | `X-Tenant-ID`            |
+| Service role header name       | `MONITORING_SERVICE_ROLE_HEADER`        | `X-Service-Role`         |
+| Default tenant                 | `MONITORING_DEFAULT_TENANT`             | `global`                 |
+| Default service role           | `MONITORING_SERVICE_ROLE`               | `unspecified`            |
 | Prometheus namespace           | `MONITORING_METRICS__NAMESPACE`         | `legacycoin`             |
 | Prometheus exporter host/port  | `MONITORING_METRICS__EXPORTER_HOST/PORT`| `0.0.0.0` / `9000`       |
 | OpenSearch host/port           | `MONITORING_OPENSEARCH__HOST/PORT`      | `localhost` / `9200`     |
 | OpenSearch index               | `MONITORING_OPENSEARCH__INDEX`          | `legacycoin-logs`        |
 | OTLP collector endpoint        | `MONITORING_TRACING__ENDPOINT`          | `http://localhost:4318`  |
+| Tenant SLO window              | `MONITORING_SLO__WINDOW_SECONDS`        | `300`                    |
+| Latency SLO target             | `MONITORING_SLO__LATENCY_TARGET_MS`     | `500`                    |
+| Error rate SLO target          | `MONITORING_SLO__ERROR_RATE_TARGET`     | `0.01`                   |
+| Throughput SLO target          | `MONITORING_SLO__THROUGHPUT_TARGET_RPS` | `1.0`                    |
+| RTO target (seconds)           | `MONITORING_SLO__RTO_TARGET_SECONDS`    | `900`                    |
+| RPO target (seconds)           | `MONITORING_SLO__RPO_TARGET_SECONDS`    | `300`                    |
+| Secrets rotation fallback      | `MONITORING_COMPLIANCE__FALLBACK_TIMESTAMP` | _unset_             |
+| Maximum secret age (days)      | `MONITORING_COMPLIANCE__MAX_SECRET_AGE_DAYS` | `90`                |
 
 Refer to [`DASHBOARDS.md`](./DASHBOARDS.md) for ready-to-import Grafana
 layouts and alert recommendations.

--- a/services/monitoring/__init__.py
+++ b/services/monitoring/__init__.py
@@ -4,6 +4,7 @@ from .config import MonitoringSettings
 from .instrumentation import instrument_fastapi_app, instrument_flask_app
 from .logging import configure_logging
 from .prometheus import HttpMetrics
+from .slo import SyntheticMonitor, TenantSLOAggregator
 from .tracing import configure_tracing
 
 __all__ = [
@@ -13,4 +14,6 @@ __all__ = [
     "configure_tracing",
     "instrument_fastapi_app",
     "instrument_flask_app",
+    "SyntheticMonitor",
+    "TenantSLOAggregator",
 ]

--- a/services/monitoring/alerts.yaml
+++ b/services/monitoring/alerts.yaml
@@ -25,3 +25,74 @@ groups:
         annotations:
           summary: "Increased latency for {{ $labels.service }}"
           description: "95th percentile response time remained above 2 seconds for five minutes."
+      - alert: TenantLatencySLOViolation
+        expr: legacycoin_tenant_latency_p95_seconds > 0.5
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Tenant latency SLO breached for {{ $labels.tenant }} ({{ $labels.service_role }})"
+          description: |
+            The 95th percentile latency exceeded the 500 ms SLO for tenant {{ $labels.tenant }}
+            in role {{ $labels.service_role }} for ten minutes. Follow the latency runbook in
+            services/monitoring/README.md#operational-runbooks before escalating.
+      - alert: TenantErrorRateSLOViolation
+        expr: legacycoin_tenant_error_rate > 0.01
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Tenant error budget burn for {{ $labels.tenant }}"
+          description: |
+            Error rate is above the 1% SLO for tenant {{ $labels.tenant }} / {{ $labels.service_role }}.
+            Inspect recent traces via Jaeger using the legacy.tenant_id attribute.
+      - alert: TenantThroughputRegression
+        expr: legacycoin_tenant_throughput_rps < 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Throughput regression detected for {{ $labels.tenant }}"
+          description: |
+            Request throughput dropped below 1 rps for tenant {{ $labels.tenant }}. Confirm synthetic
+            checks and customer traffic expectations before paging the secondary on-call.
+      - alert: SyntheticCheckFailure
+        expr: legacycoin_synthetic_check_status == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Synthetic guard-rail {{ $labels.check }} failing for {{ $labels.tenant }}"
+          description: |
+            Synthetic check {{ $labels.check }} is failing or violating RTO/RPO for tenant {{ $labels.tenant }}.
+            Investigate the synthetic endpoint and data freshness monitors immediately.
+      - alert: SyntheticRecoveryTimeBreach
+        expr: legacycoin_synthetic_check_recovery_time_seconds > 900
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RTO breach for {{ $labels.check }} ({{ $labels.tenant }})"
+          description: |
+            Recorded recovery time exceeded the 15 minute RTO target. Follow the disaster recovery
+            playbook and notify the incident commander per SOC2 escalation policy.
+      - alert: SyntheticDataLagBreach
+        expr: legacycoin_synthetic_check_data_lag_seconds > 300
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RPO breach for {{ $labels.check }}"
+          description: |
+            Synthetic data lag is beyond the five minute RPO tolerance. Validate upstream data pipelines
+            and backfill if necessary.
+      - alert: SecretsRotationStale
+        expr: legacycoin_compliance_secrets_rotation_age_days > 90
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Secrets rotation overdue for {{ $labels.tenant }}"
+          description: |
+            Secrets were rotated more than 90 days ago. Update SECRETS_ROTATED_AT and confirm evidence
+            collection for the SOC2 control.

--- a/services/monitoring/instrumentation.py
+++ b/services/monitoring/instrumentation.py
@@ -6,13 +6,21 @@ import contextlib
 import time
 from typing import Optional
 
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import Response as FastAPIResponse
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
-from crypto_bot.utils.logger import clear_correlation_id, get_correlation_id, set_correlation_id
+from pydantic import BaseModel, Field
+
+from crypto_bot.utils.logger import (
+    clear_correlation_id,
+    clear_observability_context,
+    get_correlation_id,
+    set_correlation_id,
+    set_observability_context,
+)
 
 from opentelemetry.trace import Tracer
 from opentelemetry.trace.status import Status, StatusCode
@@ -23,12 +31,25 @@ from .prometheus import HttpMetrics
 from .tracing import configure_tracing
 
 try:  # pragma: no cover - optional dependency guard for Flask environments
-    from flask import Flask, Response as FlaskResponse, g, request
+    from flask import Flask, Response as FlaskResponse, g, jsonify, request
 except Exception:  # pragma: no cover - flask may not be installed in some test contexts
     Flask = None  # type: ignore
     FlaskResponse = None  # type: ignore
     g = None  # type: ignore
+    jsonify = None  # type: ignore
     request = None  # type: ignore
+
+
+class SyntheticCheckPayload(BaseModel):
+    """Request payload for submitting synthetic check results."""
+
+    name: str
+    status: bool
+    latency_ms: float = Field(ge=0)
+    tenant: Optional[str] = Field(default=None)
+    service_role: Optional[str] = Field(default=None)
+    recovery_time_seconds: Optional[float] = Field(default=None, ge=0)
+    data_lag_seconds: Optional[float] = Field(default=None, ge=0)
 
 
 def _resolve_route(scope_route: object, path: str) -> str:
@@ -48,23 +69,41 @@ class FastAPIMonitoringMiddleware(BaseHTTPMiddleware):
         metrics: HttpMetrics,
         header_name: str,
         tracer: Optional[Tracer],
+        tenant_header: str,
+        service_role_header: str,
+        default_tenant: str,
+        default_service_role: str,
     ) -> None:
         super().__init__(app)
         self.metrics = metrics
         self.header_name = header_name
         self.tracer = tracer
+        self.tenant_header = tenant_header
+        self.service_role_header = service_role_header
+        self.default_tenant = default_tenant
+        self.default_service_role = default_service_role
 
     async def dispatch(self, request: Request, call_next):
         correlation_id = set_correlation_id(request.headers.get(self.header_name))
         route = _resolve_route(request.scope.get("route"), request.url.path)
 
+        tenant_value = request.headers.get(self.tenant_header, "") or ""
+        service_role_value = request.headers.get(self.service_role_header, "") or ""
+        tenant_id, service_role = set_observability_context(
+            tenant_id=tenant_value.strip() or self.default_tenant,
+            service_role=service_role_value.strip() or self.default_service_role,
+        )
+        extra_labels = {"tenant": tenant_id, "service_role": service_role}
+
         if route == "/metrics":
             try:
                 response = await call_next(request)
+                if hasattr(response, "headers"):
+                    response.headers[self.header_name] = correlation_id
+                return response
             finally:
+                clear_observability_context()
                 clear_correlation_id()
-            response.headers[self.header_name] = correlation_id
-            return response
 
         method = request.method.upper()
         start_time = time.perf_counter()
@@ -75,34 +114,53 @@ class FastAPIMonitoringMiddleware(BaseHTTPMiddleware):
             else contextlib.nullcontext()
         )
 
-        with span_cm as span:
-            if span is not None:
-                span.set_attribute("http.method", method)
-                span.set_attribute("http.route", route)
-                span.set_attribute("http.url", str(request.url))
-                span.set_attribute("http.scheme", request.url.scheme)
-                if request.client:
-                    span.set_attribute("http.client_ip", request.client.host)
-                span.set_attribute("legacy.correlation_id", correlation_id)
-            try:
-                response: Response = await call_next(request)
-            except Exception as exc:  # pragma: no cover - defensive logging
-                duration = time.perf_counter() - start_time
-                self.metrics.observe(method=method, route=route, status_code=500, duration=duration)
+        response: Optional[Response] = None
+        status_code = 500
+        span = None
+        try:
+            with span_cm as span:
                 if span is not None:
-                    span.record_exception(exc)
-                    span.set_status(Status(StatusCode.ERROR, str(exc)))
-                clear_correlation_id()
-                raise
-            status_code = getattr(response, "status_code", 200)
-            if span is not None:
-                span.set_attribute("http.status_code", status_code)
-
-        duration = time.perf_counter() - start_time
-        self.metrics.observe(method=method, route=route, status_code=status_code, duration=duration)
-        response.headers[self.header_name] = correlation_id
-        clear_correlation_id()
-        return response
+                    span.set_attribute("http.method", method)
+                    span.set_attribute("http.route", route)
+                    span.set_attribute("http.url", str(request.url))
+                    span.set_attribute("http.scheme", request.url.scheme)
+                    if request.client:
+                        span.set_attribute("http.client_ip", request.client.host)
+                    span.set_attribute("legacy.correlation_id", correlation_id)
+                    span.set_attribute("legacy.tenant_id", tenant_id)
+                    span.set_attribute("legacy.service_role", service_role)
+                try:
+                    response = await call_next(request)
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    duration = time.perf_counter() - start_time
+                    self.metrics.observe(
+                        method=method,
+                        route=route,
+                        status_code=500,
+                        duration=duration,
+                        extra_labels=extra_labels,
+                    )
+                    if span is not None:
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR, str(exc)))
+                    raise
+                status_code = getattr(response, "status_code", 200)
+                if span is not None:
+                    span.set_attribute("http.status_code", status_code)
+            duration = time.perf_counter() - start_time
+            self.metrics.observe(
+                method=method,
+                route=route,
+                status_code=status_code,
+                duration=duration,
+                extra_labels=extra_labels,
+            )
+            if response is not None:
+                response.headers[self.header_name] = correlation_id
+            return response
+        finally:
+            clear_observability_context()
+            clear_correlation_id()
 
 
 def _register_metrics_route(app: FastAPI, registry: CollectorRegistry) -> None:
@@ -116,6 +174,68 @@ def _register_metrics_route(app: FastAPI, registry: CollectorRegistry) -> None:
             content=generate_latest(registry),
             media_type=CONTENT_TYPE_LATEST,
         )
+
+
+def _register_fastapi_observability_routes(
+    app: FastAPI, metrics: HttpMetrics, settings: MonitoringSettings
+) -> None:
+    if getattr(app.state, "observability_routes_registered", False):
+        return
+
+    router = APIRouter(prefix="/observability", tags=["observability"])
+
+    @router.get("/slo")
+    async def slo_overview() -> list[dict[str, object]]:
+        return metrics.get_slo_snapshots()
+
+    @router.get("/slo/{tenant_id}")
+    async def slo_for_tenant(
+        tenant_id: str, service_role: Optional[str] = None
+    ) -> dict[str, object]:
+        snapshot = metrics.get_slo_snapshot(
+            tenant_id, service_role or settings.service_role
+        )
+        if snapshot is None:
+            raise HTTPException(status_code=404, detail="SLO data not found for tenant")
+        return snapshot
+
+    @router.get("/synthetic-checks")
+    async def list_synthetic_checks() -> list[dict[str, object]]:
+        return metrics.get_synthetic_checks()
+
+    @router.get("/synthetic-checks/{check_name}")
+    async def get_synthetic_check(
+        check_name: str,
+        tenant: Optional[str] = None,
+        service_role: Optional[str] = None,
+    ) -> dict[str, object]:
+        tenant_id = tenant or settings.default_tenant
+        service_role_id = service_role or settings.service_role
+        record = metrics.get_synthetic_check(check_name, tenant_id, service_role_id)
+        if record is None:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Synthetic check '{check_name}' not found for tenant "
+                    f"{tenant_id} ({service_role_id})."
+                ),
+            )
+        return record
+
+    @router.post("/synthetic-checks", status_code=201)
+    async def post_synthetic_check(payload: SyntheticCheckPayload) -> dict[str, object]:
+        return metrics.record_synthetic_check(
+            name=payload.name,
+            status=payload.status,
+            latency_ms=payload.latency_ms,
+            tenant=payload.tenant or settings.default_tenant,
+            service_role=payload.service_role or settings.service_role,
+            recovery_time_seconds=payload.recovery_time_seconds,
+            data_lag_seconds=payload.data_lag_seconds,
+        )
+
+    app.include_router(router)
+    app.state.observability_routes_registered = True
 
 
 def instrument_fastapi_app(
@@ -142,6 +262,10 @@ def instrument_fastapi_app(
         service_name=base_settings.service_name,
         environment=base_settings.environment,
         settings=base_settings.metrics,
+        slo_settings=base_settings.slo,
+        compliance_settings=base_settings.compliance,
+        default_tenant=base_settings.default_tenant,
+        default_service_role=base_settings.service_role,
     )
 
     app.add_middleware(
@@ -149,16 +273,106 @@ def instrument_fastapi_app(
         metrics=metrics,
         header_name=base_settings.correlation_header,
         tracer=tracer,
+        tenant_header=base_settings.tenant_header,
+        service_role_header=base_settings.service_role_header,
+        default_tenant=base_settings.default_tenant,
+        default_service_role=base_settings.service_role,
     )
     _register_metrics_route(app, metrics.registry)
+    _register_fastapi_observability_routes(app, metrics, base_settings)
     app.state.observability_instrumented = True
     app.state.observability_settings = base_settings
     app.state.observability_metrics = metrics
+    app.state.observability_slo = metrics.slo_aggregator
+    app.state.observability_synthetic = metrics.synthetic_monitor
     return base_settings
 
 
 def _flask_has_route(app: "Flask", rule: str) -> bool:
     return any(getattr(route, "rule", None) == rule for route in app.url_map.iter_rules())
+
+
+def _register_flask_observability_routes(
+    app: "Flask", metrics: HttpMetrics, settings: MonitoringSettings
+) -> None:
+    if Flask is None or jsonify is None:
+        return
+
+    if not _flask_has_route(app, "/observability/slo"):
+
+        @app.route("/observability/slo", methods=["GET"])
+        def flask_slo_overview() -> "FlaskResponse":  # pragma: no cover - framework glue
+            return jsonify(metrics.get_slo_snapshots())
+
+    if not _flask_has_route(app, "/observability/slo/<tenant_id>"):
+
+        @app.route("/observability/slo/<tenant_id>", methods=["GET"])
+        def flask_slo_tenant(tenant_id: str) -> "FlaskResponse":  # pragma: no cover
+            service_role = request.args.get("service_role", settings.service_role)
+            snapshot = metrics.get_slo_snapshot(tenant_id, service_role)
+            if snapshot is None:
+                return jsonify({"detail": "SLO data not found"}), 404
+            return jsonify(snapshot)
+
+    if not _flask_has_route(app, "/observability/synthetic-checks"):
+
+        @app.route("/observability/synthetic-checks", methods=["GET", "POST"])
+        def flask_synthetic_checks() -> "FlaskResponse":  # pragma: no cover - glue code
+            if request.method == "GET":
+                return jsonify(metrics.get_synthetic_checks())
+
+            payload = request.get_json(force=True, silent=True) or {}
+            try:
+                name = str(payload["name"])
+                status = bool(payload["status"])
+                latency_ms = float(payload["latency_ms"])
+            except (KeyError, TypeError, ValueError):
+                return jsonify({"detail": "Invalid synthetic check payload"}), 400
+
+            tenant = str(payload.get("tenant") or settings.default_tenant)
+            service_role = str(payload.get("service_role") or settings.service_role)
+
+            recovery_time = payload.get("recovery_time_seconds")
+            data_lag = payload.get("data_lag_seconds")
+            try:
+                recovery_time_val = (
+                    None if recovery_time is None else float(recovery_time)
+                )
+                data_lag_val = None if data_lag is None else float(data_lag)
+            except (TypeError, ValueError):
+                return jsonify({"detail": "Invalid recovery/data lag values"}), 400
+
+            record = metrics.record_synthetic_check(
+                name=name,
+                status=status,
+                latency_ms=latency_ms,
+                tenant=tenant,
+                service_role=service_role,
+                recovery_time_seconds=recovery_time_val,
+                data_lag_seconds=data_lag_val,
+            )
+            return jsonify(record), 201
+
+    if not _flask_has_route(app, "/observability/synthetic-checks/<check_name>"):
+
+        @app.route("/observability/synthetic-checks/<check_name>", methods=["GET"])
+        def flask_synthetic_check_detail(check_name: str) -> "FlaskResponse":
+            tenant = request.args.get("tenant", settings.default_tenant)
+            service_role = request.args.get("service_role", settings.service_role)
+            record = metrics.get_synthetic_check(check_name, tenant, service_role)
+            if record is None:
+                return (
+                    jsonify(
+                        {
+                            "detail": (
+                                f"Synthetic check '{check_name}' not found for tenant "
+                                f"{tenant} ({service_role})."
+                            )
+                        }
+                    ),
+                    404,
+                )
+            return jsonify(record)
 
 
 def instrument_flask_app(
@@ -188,6 +402,10 @@ def instrument_flask_app(
         service_name=base_settings.service_name,
         environment=base_settings.environment,
         settings=base_settings.metrics,
+        slo_settings=base_settings.slo,
+        compliance_settings=base_settings.compliance,
+        default_tenant=base_settings.default_tenant,
+        default_service_role=base_settings.service_role,
     )
     header_name = base_settings.correlation_header
 
@@ -199,6 +417,16 @@ def instrument_flask_app(
         g._method = request.method.upper()
         g._start_time = time.perf_counter()
         g._correlation_id = correlation_id
+        tenant_value = request.headers.get(base_settings.tenant_header, "") or ""
+        service_role_value = (
+            request.headers.get(base_settings.service_role_header, "") or ""
+        )
+        tenant_id, service_role = set_observability_context(
+            tenant_id=tenant_value.strip() or base_settings.default_tenant,
+            service_role=service_role_value.strip() or base_settings.service_role,
+        )
+        g._tenant_id = tenant_id
+        g._service_role = service_role
         if tracer is not None:
             span_cm = tracer.start_as_current_span(f"{g._method} {g._route}")
             g._span_cm = span_cm
@@ -207,6 +435,8 @@ def instrument_flask_app(
             span.set_attribute("http.method", g._method)
             span.set_attribute("http.route", g._route)
             span.set_attribute("legacy.correlation_id", correlation_id)
+            span.set_attribute("legacy.tenant_id", tenant_id)
+            span.set_attribute("legacy.service_role", service_role)
         else:
             g._span_cm = None
             g._span = None
@@ -216,8 +446,17 @@ def instrument_flask_app(
         correlation_id = getattr(g, "_correlation_id", get_correlation_id())
         route = getattr(g, "_route", request.path)
         method = getattr(g, "_method", request.method.upper())
+        tenant_id = getattr(g, "_tenant_id", base_settings.default_tenant)
+        service_role = getattr(g, "_service_role", base_settings.service_role)
         duration = time.perf_counter() - getattr(g, "_start_time", time.perf_counter())
-        metrics.observe(method=method, route=route, status_code=response.status_code, duration=duration)
+        if route != "/metrics":
+            metrics.observe(
+                method=method,
+                route=route,
+                status_code=response.status_code,
+                duration=duration,
+                extra_labels={"tenant": tenant_id, "service_role": service_role},
+            )
         response.headers[header_name] = correlation_id
         span = getattr(g, "_span", None)
         span_cm = getattr(g, "_span_cm", None)
@@ -226,6 +465,7 @@ def instrument_flask_app(
         if span_cm is not None:
             span_cm.__exit__(None, None, None)
             g._span_cm = None
+        clear_observability_context()
         clear_correlation_id()
         g._observed = True
         return response
@@ -236,8 +476,16 @@ def instrument_flask_app(
             correlation_id = getattr(g, "_correlation_id", get_correlation_id())
             route = getattr(g, "_route", request.path)
             method = getattr(g, "_method", request.method.upper())
+            tenant_id = getattr(g, "_tenant_id", base_settings.default_tenant)
+            service_role = getattr(g, "_service_role", base_settings.service_role)
             duration = time.perf_counter() - getattr(g, "_start_time", time.perf_counter())
-            metrics.observe(method=method, route=route, status_code=500, duration=duration)
+            metrics.observe(
+                method=method,
+                route=route,
+                status_code=500,
+                duration=duration,
+                extra_labels={"tenant": tenant_id, "service_role": service_role},
+            )
             span = getattr(g, "_span", None)
             span_cm = getattr(g, "_span_cm", None)
             if span is not None:
@@ -245,6 +493,7 @@ def instrument_flask_app(
                 span.set_status(Status(StatusCode.ERROR, str(exc)))
             if span_cm is not None:
                 span_cm.__exit__(type(exc), exc, getattr(exc, "__traceback__", None))
+        clear_observability_context()
         clear_correlation_id()
 
     if not _flask_has_route(app, "/metrics"):
@@ -253,9 +502,12 @@ def instrument_flask_app(
             payload = generate_latest(metrics.registry)
             return FlaskResponse(payload, mimetype=CONTENT_TYPE_LATEST)
 
+    _register_flask_observability_routes(app, metrics, base_settings)
     app.config["OBSERVABILITY_INSTRUMENTED"] = True
     app.config["OBSERVABILITY_SETTINGS"] = base_settings
     app.config["OBSERVABILITY_METRICS"] = metrics
+    app.config["OBSERVABILITY_SLO"] = metrics.slo_aggregator
+    app.config["OBSERVABILITY_SYNTHETIC"] = metrics.synthetic_monitor
     return base_settings
 
 

--- a/services/monitoring/logging.py
+++ b/services/monitoring/logging.py
@@ -6,7 +6,11 @@ import json
 import logging
 from typing import Optional
 
-from crypto_bot.utils.logger import register_centralized_handler, setup_logger
+from crypto_bot.utils.logger import (
+    register_centralized_handler,
+    set_default_observability_context,
+    setup_logger,
+)
 
 from .config import MonitoringSettings, OpenSearchSettings
 
@@ -75,6 +79,11 @@ def configure_logging(settings: MonitoringSettings) -> logging.Logger:
 
     logger = setup_logger(settings.service_name)
     logger.setLevel(getattr(logging, settings.log_level.upper(), logging.INFO))
+
+    set_default_observability_context(
+        tenant_id=settings.default_tenant,
+        service_role=settings.service_role,
+    )
 
     if settings.opensearch.enabled:
         handler = OpenSearchLogHandler(settings.opensearch)

--- a/services/monitoring/prometheus.py
+++ b/services/monitoring/prometheus.py
@@ -2,46 +2,101 @@
 
 from __future__ import annotations
 
+import os
 import time
-from dataclasses import dataclass
-from typing import Dict, Optional
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
-from prometheus_client import Counter, Histogram, REGISTRY, CollectorRegistry
+from prometheus_client import (
+    REGISTRY,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+)
 
-from .config import MetricsSettings
+from crypto_bot.utils.logger import get_service_role, get_tenant_id
+
+from .config import ComplianceSettings, MetricsSettings, SLOSettings
+from .slo import SyntheticMonitor, TenantSLOAggregator, TenantSLOSnapshot
 
 
 @dataclass
 class HttpMetrics:
-    """Track HTTP metrics for a specific service."""
+    """Track HTTP metrics, tenant SLOs and synthetic guard-rails for a service."""
 
     service_name: str
     environment: str
     settings: MetricsSettings
+    slo_settings: SLOSettings
+    compliance_settings: ComplianceSettings
+    default_tenant: str
+    default_service_role: str
     registry: CollectorRegistry = REGISTRY
+    request_counter: Counter = field(init=False)
+    error_counter: Counter = field(init=False)
+    latency_histogram: Histogram = field(init=False)
+    slo_latency_gauge: Gauge = field(init=False)
+    slo_error_rate_gauge: Gauge = field(init=False)
+    slo_throughput_gauge: Gauge = field(init=False)
+    synthetic_status_gauge: Gauge = field(init=False)
+    synthetic_latency_gauge: Gauge = field(init=False)
+    synthetic_rto_gauge: Gauge = field(init=False)
+    synthetic_rpo_gauge: Gauge = field(init=False)
+    compliance_rotation_timestamp_gauge: Gauge = field(init=False)
+    compliance_rotation_age_gauge: Gauge = field(init=False)
+    slo_aggregator: TenantSLOAggregator = field(init=False)
+    synthetic_monitor: SyntheticMonitor = field(init=False)
+    _static_labels: Dict[str, str] = field(init=False)
+    _secrets_rotation_epoch: Optional[float] = field(init=False, default=None)
 
     def __post_init__(self) -> None:
+        self.slo_aggregator = TenantSLOAggregator(
+            window_seconds=self.slo_settings.window_seconds,
+            latency_target_ms=self.slo_settings.latency_target_ms,
+            error_rate_target=self.slo_settings.error_rate_target,
+            throughput_target_rps=self.slo_settings.throughput_target_rps,
+        )
+        self.synthetic_monitor = SyntheticMonitor(
+            rto_target_seconds=self.slo_settings.rto_target_seconds,
+            rpo_target_seconds=self.slo_settings.rpo_target_seconds,
+        )
+        self._static_labels = {
+            "service": self.service_name,
+            "environment": self.environment,
+        }
+        if self.settings.default_labels:
+            self._static_labels.update(self.settings.default_labels)
+        self._secrets_rotation_epoch = self._resolve_secrets_rotation_epoch()
         self._initialise_metrics(self.registry)
+        if self._secrets_rotation_epoch is not None:
+            self._publish_compliance_metrics(
+                self.default_tenant, self.default_service_role
+            )
 
     def _initialise_metrics(self, registry: CollectorRegistry) -> None:
         extra = []
         if self.settings.default_labels:
             extra = sorted(self.settings.default_labels.keys())
-        labels = ["service", "environment", *extra, "method", "route", "status"]
-        latency_labels = ["service", "environment", *extra, "method", "route"]
+        base = ["service", "environment", *extra, "tenant", "service_role"]
+        request_labels = [*base, "method", "route", "status"]
+        latency_labels = [*base, "method", "route"]
+        slo_labels = base
+        synthetic_labels = [*base, "check"]
         namespace = self.settings.namespace
         try:
             self.request_counter = Counter(
                 "http_requests_total",
                 "Total count of HTTP requests.",
-                labels,
+                request_labels,
                 namespace=namespace,
                 registry=registry,
             )
             self.error_counter = Counter(
                 "http_request_errors_total",
                 "Total count of failed HTTP requests.",
-                labels,
+                request_labels,
                 namespace=namespace,
                 registry=registry,
             )
@@ -52,14 +107,115 @@ class HttpMetrics:
                 namespace=namespace,
                 registry=registry,
             )
+            self.slo_latency_gauge = Gauge(
+                "tenant_latency_p95_seconds",
+                "95th percentile latency per tenant/service role over the SLO window.",
+                slo_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.slo_error_rate_gauge = Gauge(
+                "tenant_error_rate",
+                "Error rate per tenant/service role over the SLO window.",
+                slo_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.slo_throughput_gauge = Gauge(
+                "tenant_throughput_rps",
+                "Average request throughput per tenant/service role (requests per second).",
+                slo_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.synthetic_status_gauge = Gauge(
+                "synthetic_check_status",
+                "Synthetic check compliance status (1 = passing).",
+                synthetic_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.synthetic_latency_gauge = Gauge(
+                "synthetic_check_latency_seconds",
+                "Latency of synthetic checks in seconds.",
+                synthetic_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.synthetic_rto_gauge = Gauge(
+                "synthetic_check_recovery_time_seconds",
+                "Observed recovery time from synthetic checks.",
+                synthetic_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.synthetic_rpo_gauge = Gauge(
+                "synthetic_check_data_lag_seconds",
+                "Observed data lag from synthetic checks.",
+                synthetic_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.compliance_rotation_timestamp_gauge = Gauge(
+                "compliance_secrets_rotation_timestamp_seconds",
+                "Timestamp of the last secrets rotation for compliance tracking.",
+                slo_labels,
+                namespace=namespace,
+                registry=registry,
+            )
+            self.compliance_rotation_age_gauge = Gauge(
+                "compliance_secrets_rotation_age_days",
+                "Age in days since the last secrets rotation event.",
+                slo_labels,
+                namespace=namespace,
+                registry=registry,
+            )
         except ValueError:
-            # Fall back to a dedicated registry when another service already registered
-            # the same metrics in the default collector.
             fresh_registry = CollectorRegistry()
             self.registry = fresh_registry
             self._initialise_metrics(fresh_registry)
             return
         self.registry = registry
+
+    def _context_labels(self, tenant: str, service_role: str) -> Dict[str, str]:
+        labels = dict(self._static_labels)
+        labels.update({"tenant": tenant, "service_role": service_role})
+        return labels
+
+    def _resolve_secrets_rotation_epoch(self) -> Optional[float]:
+        if not self.compliance_settings.enabled:
+            return None
+        env_key = self.compliance_settings.secrets_rotated_env
+        value = os.getenv(env_key)
+        if not value and self.compliance_settings.fallback_timestamp:
+            value = self.compliance_settings.fallback_timestamp
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                return None
+        return parsed.astimezone(timezone.utc).timestamp()
+
+    def _publish_compliance_metrics(self, tenant: str, service_role: str) -> None:
+        if self._secrets_rotation_epoch is None:
+            return
+        labels = self._context_labels(tenant, service_role)
+        now = time.time()
+        self.compliance_rotation_timestamp_gauge.labels(**labels).set(
+            self._secrets_rotation_epoch
+        )
+        age_days = max((now - self._secrets_rotation_epoch) / 86400.0, 0.0)
+        self.compliance_rotation_age_gauge.labels(**labels).set(age_days)
+
+    def _update_slo_gauges(self, snapshot: TenantSLOSnapshot) -> None:
+        labels = self._context_labels(snapshot.tenant, snapshot.service_role)
+        self.slo_latency_gauge.labels(**labels).set(snapshot.p95_latency_ms / 1000.0)
+        self.slo_error_rate_gauge.labels(**labels).set(snapshot.error_rate)
+        self.slo_throughput_gauge.labels(**labels).set(snapshot.throughput_rps)
 
     def observe(
         self,
@@ -72,22 +228,89 @@ class HttpMetrics:
     ) -> None:
         """Record metrics for a completed HTTP request."""
 
-        base_labels = {
-            "service": self.service_name,
-            "environment": self.environment,
-            "method": method,
-            "route": route,
-        }
-        if self.settings.default_labels:
-            base_labels.update(self.settings.default_labels)
-        if extra_labels:
-            base_labels.update(extra_labels)
+        overrides = dict(extra_labels or {})
+        tenant = overrides.pop("tenant", None) or get_tenant_id() or self.default_tenant
+        service_role = (
+            overrides.pop("service_role", None)
+            or get_service_role()
+            or self.default_service_role
+        )
+        context = self._context_labels(tenant, service_role)
+        if overrides:
+            context.update(overrides)
 
-        labels = {**base_labels, "status": str(status_code)}
-        self.request_counter.labels(**labels).inc()
+        base = {**context, "method": method, "route": route}
+        counter_labels = {**base, "status": str(status_code)}
+        self.request_counter.labels(**counter_labels).inc()
         if status_code >= 500:
-            self.error_counter.labels(**labels).inc()
-        self.latency_histogram.labels(**base_labels).observe(duration)
+            self.error_counter.labels(**counter_labels).inc()
+        self.latency_histogram.labels(**base).observe(duration)
+
+        snapshot = self.slo_aggregator.add_sample(
+            tenant=tenant,
+            service_role=service_role,
+            method=method,
+            route=route,
+            status_code=status_code,
+            duration=duration,
+        )
+        self._update_slo_gauges(snapshot)
+        self._publish_compliance_metrics(tenant, service_role)
+
+    def record_synthetic_check(
+        self,
+        *,
+        name: str,
+        status: bool,
+        latency_ms: float,
+        tenant: Optional[str] = None,
+        service_role: Optional[str] = None,
+        recovery_time_seconds: Optional[float] = None,
+        data_lag_seconds: Optional[float] = None,
+    ) -> Dict[str, object]:
+        tenant_id = tenant or self.default_tenant
+        service_role_id = service_role or self.default_service_role
+        check = self.synthetic_monitor.record_check(
+            name=name,
+            tenant=tenant_id,
+            service_role=service_role_id,
+            status=status,
+            latency_seconds=latency_ms / 1000.0,
+            recovery_time_seconds=recovery_time_seconds,
+            data_lag_seconds=data_lag_seconds,
+        )
+        labels = self._context_labels(tenant_id, service_role_id)
+        metric_labels = {**labels, "check": name}
+        self.synthetic_status_gauge.labels(**metric_labels).set(1.0 if check.overall_ok else 0.0)
+        self.synthetic_latency_gauge.labels(**metric_labels).set(check.latency_seconds)
+        self.synthetic_rto_gauge.labels(**metric_labels).set(
+            check.recovery_time_seconds or 0.0
+        )
+        self.synthetic_rpo_gauge.labels(**metric_labels).set(check.data_lag_seconds or 0.0)
+        self._publish_compliance_metrics(tenant_id, service_role_id)
+        return check.to_dict()
+
+    def get_slo_snapshots(self) -> List[Dict[str, object]]:
+        return [snapshot.to_dict() for snapshot in self.slo_aggregator.get_all_snapshots()]
+
+    def get_slo_snapshot(
+        self, tenant: str, service_role: Optional[str] = None
+    ) -> Optional[Dict[str, object]]:
+        snapshot = self.slo_aggregator.get_snapshot(tenant, service_role)
+        if snapshot is None:
+            return None
+        return snapshot.to_dict()
+
+    def get_synthetic_checks(self) -> List[Dict[str, object]]:
+        return [check.to_dict() for check in self.synthetic_monitor.get_all()]
+
+    def get_synthetic_check(
+        self, name: str, tenant: str, service_role: str
+    ) -> Optional[Dict[str, object]]:
+        check = self.synthetic_monitor.get_check(name, tenant, service_role)
+        if check is None:
+            return None
+        return check.to_dict()
 
     def time(self, method: str, route: str):  # pragma: no cover - simple helper
         start = time.perf_counter()

--- a/services/monitoring/slo.py
+++ b/services/monitoring/slo.py
@@ -1,0 +1,331 @@
+"""Runtime helpers for tenant SLO tracking and synthetic guard-rail checks."""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from threading import Lock
+from typing import Deque, Dict, Iterable, List, Optional, Tuple
+
+
+@dataclass
+class SLOSample:
+    """Single request observation used for rolling SLO calculations."""
+
+    timestamp: float
+    duration: float
+    status_code: int
+    method: str
+    route: str
+
+
+@dataclass
+class TenantSLOSnapshot:
+    """Aggregated SLO view for a tenant/service-role pairing."""
+
+    tenant: str
+    service_role: str
+    window_seconds: int
+    request_count: int
+    error_count: int
+    average_latency_ms: float
+    p95_latency_ms: float
+    error_rate: float
+    throughput_rps: float
+    latency_target_ms: float
+    latency_slo_met: bool
+    error_rate_target: float
+    error_rate_slo_met: bool
+    throughput_target_rps: float
+    throughput_slo_met: bool
+    last_updated: float
+
+    def to_dict(self) -> Dict[str, float | int | str | bool]:
+        """Return a serialisable representation of the snapshot."""
+
+        return {
+            "tenant": self.tenant,
+            "service_role": self.service_role,
+            "window_seconds": self.window_seconds,
+            "request_count": self.request_count,
+            "error_count": self.error_count,
+            "average_latency_ms": self.average_latency_ms,
+            "p95_latency_ms": self.p95_latency_ms,
+            "error_rate": self.error_rate,
+            "throughput_rps": self.throughput_rps,
+            "latency_target_ms": self.latency_target_ms,
+            "latency_slo_met": self.latency_slo_met,
+            "error_rate_target": self.error_rate_target,
+            "error_rate_slo_met": self.error_rate_slo_met,
+            "throughput_target_rps": self.throughput_target_rps,
+            "throughput_slo_met": self.throughput_slo_met,
+            "last_updated": self.last_updated,
+        }
+
+
+def _percentile(values: List[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * percentile
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return ordered[int(k)]
+    lower = ordered[f] * (c - k)
+    upper = ordered[c] * (k - f)
+    return lower + upper
+
+
+class TenantSLOAggregator:
+    """Maintain rolling SLO metrics per tenant and service role."""
+
+    def __init__(
+        self,
+        *,
+        window_seconds: int,
+        latency_target_ms: float,
+        error_rate_target: float,
+        throughput_target_rps: float,
+    ) -> None:
+        self.window_seconds = window_seconds
+        self.latency_target_ms = latency_target_ms
+        self.error_rate_target = error_rate_target
+        self.throughput_target_rps = throughput_target_rps
+        self._samples: Dict[Tuple[str, str], Deque[SLOSample]] = defaultdict(deque)
+        self._lock = Lock()
+
+    def _trim(self, samples: Deque[SLOSample], now: float) -> None:
+        cutoff = now - self.window_seconds
+        while samples and samples[0].timestamp < cutoff:
+            samples.popleft()
+
+    def _build_snapshot(
+        self,
+        key: Tuple[str, str],
+        samples: Iterable[SLOSample],
+        now: float,
+    ) -> TenantSLOSnapshot:
+        tenant, service_role = key
+        sample_list = list(samples)
+        request_count = len(sample_list)
+        error_count = sum(1 for sample in sample_list if sample.status_code >= 500)
+        latencies = [sample.duration for sample in sample_list]
+        average_latency = sum(latencies) / request_count if request_count else 0.0
+        p95_latency = _percentile(latencies, 0.95) if request_count else 0.0
+        error_rate = error_count / request_count if request_count else 0.0
+        throughput = request_count / self.window_seconds if self.window_seconds else 0.0
+        last_updated = sample_list[-1].timestamp if sample_list else now
+        return TenantSLOSnapshot(
+            tenant=tenant,
+            service_role=service_role,
+            window_seconds=self.window_seconds,
+            request_count=request_count,
+            error_count=error_count,
+            average_latency_ms=average_latency * 1000.0,
+            p95_latency_ms=p95_latency * 1000.0,
+            error_rate=error_rate,
+            throughput_rps=throughput,
+            latency_target_ms=self.latency_target_ms,
+            latency_slo_met=(p95_latency * 1000.0) <= self.latency_target_ms
+            if request_count
+            else True,
+            error_rate_target=self.error_rate_target,
+            error_rate_slo_met=error_rate <= self.error_rate_target if request_count else True,
+            throughput_target_rps=self.throughput_target_rps,
+            throughput_slo_met=throughput >= self.throughput_target_rps if request_count else True,
+            last_updated=last_updated,
+        )
+
+    def add_sample(
+        self,
+        *,
+        tenant: str,
+        service_role: str,
+        method: str,
+        route: str,
+        status_code: int,
+        duration: float,
+        timestamp: Optional[float] = None,
+    ) -> TenantSLOSnapshot:
+        """Record a new request observation and return the latest snapshot."""
+
+        now = timestamp or time.time()
+        sample = SLOSample(
+            timestamp=now,
+            duration=duration,
+            status_code=status_code,
+            method=method,
+            route=route,
+        )
+        key = (tenant, service_role)
+        with self._lock:
+            bucket = self._samples[key]
+            bucket.append(sample)
+            self._trim(bucket, now)
+            return self._build_snapshot(key, bucket, now)
+
+    def get_snapshot(
+        self, tenant: str, service_role: Optional[str] = None
+    ) -> Optional[TenantSLOSnapshot]:
+        """Return the latest snapshot for a tenant (optionally scoping by role)."""
+
+        now = time.time()
+        with self._lock:
+            if service_role is not None:
+                key = (tenant, service_role)
+                bucket = self._samples.get(key)
+                if not bucket:
+                    return None
+                self._trim(bucket, now)
+                if not bucket:
+                    return None
+                return self._build_snapshot(key, bucket, now)
+
+            merged: List[SLOSample] = []
+            for (existing_tenant, existing_role), bucket in self._samples.items():
+                if existing_tenant != tenant:
+                    continue
+                self._trim(bucket, now)
+                merged.extend(bucket)
+            if not merged:
+                return None
+            merged.sort(key=lambda sample: sample.timestamp)
+            return self._build_snapshot((tenant, "aggregate"), merged, now)
+
+    def get_all_snapshots(self) -> List[TenantSLOSnapshot]:
+        """Return snapshots for every tracked tenant/service role."""
+
+        now = time.time()
+        snapshots: List[TenantSLOSnapshot] = []
+        with self._lock:
+            for key, bucket in self._samples.items():
+                self._trim(bucket, now)
+                if not bucket:
+                    continue
+                snapshots.append(self._build_snapshot(key, bucket, now))
+        snapshots.sort(key=lambda snapshot: (snapshot.tenant, snapshot.service_role))
+        return snapshots
+
+
+@dataclass
+class SyntheticCheckStatus:
+    """Outcome of a synthetic guard-rail execution."""
+
+    name: str
+    tenant: str
+    service_role: str
+    status: bool
+    latency_seconds: float
+    checked_at: float
+    recovery_time_seconds: Optional[float]
+    data_lag_seconds: Optional[float]
+    rto_target_seconds: float
+    rpo_target_seconds: float
+
+    @property
+    def is_rto_compliant(self) -> bool:
+        if self.recovery_time_seconds is None:
+            return True
+        if self.rto_target_seconds <= 0:
+            return True
+        return self.recovery_time_seconds <= self.rto_target_seconds
+
+    @property
+    def is_rpo_compliant(self) -> bool:
+        if self.data_lag_seconds is None:
+            return True
+        if self.rpo_target_seconds <= 0:
+            return True
+        return self.data_lag_seconds <= self.rpo_target_seconds
+
+    @property
+    def overall_ok(self) -> bool:
+        return self.status and self.is_rto_compliant and self.is_rpo_compliant
+
+    def to_dict(self) -> Dict[str, float | int | str | bool | None]:
+        return {
+            "name": self.name,
+            "tenant": self.tenant,
+            "service_role": self.service_role,
+            "status": self.status,
+            "latency_seconds": self.latency_seconds,
+            "checked_at": self.checked_at,
+            "recovery_time_seconds": self.recovery_time_seconds,
+            "data_lag_seconds": self.data_lag_seconds,
+            "rto_target_seconds": self.rto_target_seconds,
+            "rpo_target_seconds": self.rpo_target_seconds,
+            "rto_compliant": self.is_rto_compliant,
+            "rpo_compliant": self.is_rpo_compliant,
+            "overall_compliant": self.overall_ok,
+        }
+
+
+class SyntheticMonitor:
+    """Maintain synthetic check health for RTO/RPO monitoring."""
+
+    def __init__(self, *, rto_target_seconds: float, rpo_target_seconds: float) -> None:
+        self.rto_target_seconds = rto_target_seconds
+        self.rpo_target_seconds = rpo_target_seconds
+        self._lock = Lock()
+        self._checks: Dict[Tuple[str, str, str], SyntheticCheckStatus] = {}
+
+    def record_check(
+        self,
+        *,
+        name: str,
+        tenant: str,
+        service_role: str,
+        status: bool,
+        latency_seconds: float,
+        recovery_time_seconds: Optional[float] = None,
+        data_lag_seconds: Optional[float] = None,
+        timestamp: Optional[float] = None,
+    ) -> SyntheticCheckStatus:
+        """Store the latest check result and return the resulting status."""
+
+        checked_at = timestamp or time.time()
+        record = SyntheticCheckStatus(
+            name=name,
+            tenant=tenant,
+            service_role=service_role,
+            status=status,
+            latency_seconds=latency_seconds,
+            checked_at=checked_at,
+            recovery_time_seconds=recovery_time_seconds,
+            data_lag_seconds=data_lag_seconds,
+            rto_target_seconds=self.rto_target_seconds,
+            rpo_target_seconds=self.rpo_target_seconds,
+        )
+        with self._lock:
+            self._checks[(tenant, service_role, name)] = record
+        return record
+
+    def get_check(
+        self, name: str, tenant: str, service_role: str
+    ) -> Optional[SyntheticCheckStatus]:
+        """Return the latest status for the requested synthetic check."""
+
+        with self._lock:
+            return self._checks.get((tenant, service_role, name))
+
+    def get_all(self) -> List[SyntheticCheckStatus]:
+        """Return all known synthetic check statuses."""
+
+        with self._lock:
+            return sorted(
+                self._checks.values(),
+                key=lambda record: (record.tenant, record.service_role, record.name),
+            )
+
+
+__all__ = [
+    "TenantSLOAggregator",
+    "TenantSLOSnapshot",
+    "SyntheticMonitor",
+    "SyntheticCheckStatus",
+]

--- a/services/monitoring/tracing.py
+++ b/services/monitoring/tracing.py
@@ -21,6 +21,8 @@ def _build_resource(settings: MonitoringSettings) -> Resource:
         "service.name": settings.service_name,
         "service.namespace": settings.tracing.service_namespace,
         "deployment.environment": settings.environment,
+        "legacy.service_role": settings.service_role,
+        "legacy.default_tenant": settings.default_tenant,
     }
     attributes.update(settings.metrics.default_labels)
     return Resource.create(attributes)


### PR DESCRIPTION
## Summary
- add tenant and service role context propagation utilities and settings to monitoring
- extend HttpMetrics with per-tenant SLO aggregation, synthetic guard-rail tracking, and compliance gauges
- expose new /observability APIs for FastAPI and Flask while updating dashboards, alerts, and documentation for SOC2 runbooks

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'asgiref'; ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68cae92f2ca083309f7e143b33391764