### PR TITLE
Add hybrid migration toolkit and deployment enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ config.yaml.backup
 *.csv
 *.json
 !tests/regression/fixtures/**/*.json
+!tests/fixtures/migration/*.json
 !sample_solana_trades.json
 
 # Additional patterns to prevent tracking of temporary files

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,15 @@ test-results: ## View test results
 observability-check: ## Validate observability instrumentation
 	pytest tests/test_observability.py
 
+migration-audit: ## Run post-migration data integrity validation against fixture snapshots
+	@mkdir -p test_results
+	python tools/migration/tenant_migration.py audit \
+		--legacy-snapshot tests/fixtures/migration/legacy_snapshot.json \
+		--modern-snapshot tests/fixtures/migration/modern_snapshot.json \
+		--report-path test_results/migration_audit_report.json \
+		--tolerance 0.0 \
+		--fail-on-drift
+
 # Service Management
 build: ## Build all services
 	docker-compose build
@@ -134,6 +143,7 @@ lint: ## Lint Python code
 
 # CI/CD
 ci-test: ## Run tests in CI environment
+	$(MAKE) migration-audit
 	$(MAKE) observability-check
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --build e2e-tests
 

--- a/deploy/helm/api-gateway/templates/deployment.yaml
+++ b/deploy/helm/api-gateway/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/api-gateway/values.yaml
+++ b/deploy/helm/api-gateway/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/execution/templates/deployment.yaml
+++ b/deploy/helm/execution/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/execution/values.yaml
+++ b/deploy/helm/execution/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/market-data/templates/deployment.yaml
+++ b/deploy/helm/market-data/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/market-data/values.yaml
+++ b/deploy/helm/market-data/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/portfolio/templates/deployment.yaml
+++ b/deploy/helm/portfolio/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/portfolio/values.yaml
+++ b/deploy/helm/portfolio/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/strategy-engine/templates/deployment.yaml
+++ b/deploy/helm/strategy-engine/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/strategy-engine/values.yaml
+++ b/deploy/helm/strategy-engine/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/token-discovery/templates/deployment.yaml
+++ b/deploy/helm/token-discovery/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/token-discovery/values.yaml
+++ b/deploy/helm/token-discovery/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/deploy/helm/trading-engine/templates/deployment.yaml
+++ b/deploy/helm/trading-engine/templates/deployment.yaml
@@ -52,9 +52,21 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-{{- if .Values.env }}
+{{- $featureFlags := default dict .Values.featureFlags }}
+{{- $cutoverControls := default dict .Values.cutoverControls }}
+{{- if or .Values.env (gt (len (keys $featureFlags)) 0) (gt (len (keys $cutoverControls)) 0) }}
           env:
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- range $name, $value := $featureFlags }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range $name, $value := $cutoverControls }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.envFrom }}
           envFrom:

--- a/deploy/helm/trading-engine/values.yaml
+++ b/deploy/helm/trading-engine/values.yaml
@@ -24,6 +24,20 @@ securityContext: {}
 env: []
 envFrom: []
 
+featureFlags:
+  HYBRID_MODE_ENABLED: false
+  LEGACY_READ_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+  HYBRID_READ_STRATEGY: compare
+  CUTOVER_COMPLETED: false
+  CUTOVER_GUARDRAIL_ENABLED: true
+  MIGRATION_DRIFT_TOLERANCE: "0.0"
+
+cutoverControls:
+  CUTOVER_TARGET_TIMESTAMP: ""
+  LEGACY_SERVICE_BASE_URL: ""
+  MODERN_SERVICE_BASE_URL: ""
+
 service:
   type: ClusterIP
   port: 80

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,8 @@ services:
   # Override for development - mount source code for hot reloading
   api-gateway:
     environment:
-      - GATEWAY_LOG_LEVEL=DEBUG
+      GATEWAY_LOG_LEVEL: DEBUG
+      HYBRID_FEATURE_FLAG_SOURCE: local-dev
     volumes:
       - ./services/api_gateway:/app
       - /app/__pycache__  # Exclude cache
@@ -22,10 +23,17 @@ services:
       "--reload"
     ]
 
+  legacy-monolith:
+    environment:
+      LEGACY_LOG_LEVEL: DEBUG
+      LEGACY_CONFIG_PATH: /opt/legacy/app/config/config.yaml
+    volumes:
+      - .:/opt/legacy/app
+
   trading-engine:
     environment:
-      - TRADING_ENGINE_LOG_LEVEL=DEBUG
-      - TRADING_ENGINE_CYCLE_INTERVAL=300  # Slower cycles for development
+      TRADING_ENGINE_LOG_LEVEL: DEBUG
+      TRADING_ENGINE_CYCLE_INTERVAL: 300  # Slower cycles for development
     volumes:
       - ./services/trading_engine:/app/services/trading_engine
       - ./services/interface_layer:/app/services/interface_layer
@@ -33,8 +41,8 @@ services:
 
   market-data:
     environment:
-      - MARKET_DATA_LOG_LEVEL=DEBUG
-      - MARKET_DATA_CACHE_ENABLED=false  # Disable caching for development
+      MARKET_DATA_LOG_LEVEL: DEBUG
+      MARKET_DATA_CACHE_ENABLED: 'false'  # Disable caching for development
     volumes:
       - ./services/market_data:/app
       - ./crypto_bot:/app/crypto_bot
@@ -42,8 +50,8 @@ services:
 
   portfolio:
     environment:
-      - PORTFOLIO_LOG_LEVEL=DEBUG
-      - PORTFOLIO_PAPER_TRADING=true  # Force paper trading in development
+      PORTFOLIO_LOG_LEVEL: DEBUG
+      PORTFOLIO_PAPER_TRADING: 'true'  # Force paper trading in development
     volumes:
       - ./services/portfolio:/app
       - ./crypto_bot:/app/crypto_bot
@@ -51,7 +59,7 @@ services:
 
   strategy-engine:
     environment:
-      - STRATEGY_ENGINE_LOG_LEVEL=DEBUG
+      STRATEGY_ENGINE_LOG_LEVEL: DEBUG
     volumes:
       - ./services/strategy_engine:/app
       - ./crypto_bot:/app/crypto_bot
@@ -59,8 +67,8 @@ services:
 
   token-discovery:
     environment:
-      - TOKEN_DISCOVERY_LOG_LEVEL=DEBUG
-      - TOKEN_DISCOVERY_SCAN_INTERVAL=60  # Faster scanning for development
+      TOKEN_DISCOVERY_LOG_LEVEL: DEBUG
+      TOKEN_DISCOVERY_SCAN_INTERVAL: 60  # Faster scanning for development
     volumes:
       - ./services/token_discovery:/app
       - ./crypto_bot:/app/crypto_bot
@@ -68,8 +76,8 @@ services:
 
   execution:
     environment:
-      - EXECUTION_LOG_LEVEL=DEBUG
-      - EXECUTION_DRY_RUN=true  # Force dry run in development
+      EXECUTION_LOG_LEVEL: DEBUG
+      EXECUTION_DRY_RUN: 'true'  # Force dry run in development
     volumes:
       - ./services/execution:/app
       - ./crypto_bot:/app/crypto_bot
@@ -78,7 +86,7 @@ services:
 
   monitoring:
     environment:
-      - MONITORING_LOG_LEVEL=DEBUG
+      MONITORING_LOG_LEVEL: DEBUG
     volumes:
       - ./services/monitoring:/app
       - ./crypto_bot:/app/crypto_bot
@@ -87,8 +95,9 @@ services:
 
   frontend:
     environment:
-      - FLASK_ENV=development
-      - FLASK_DEBUG=1
+      FLASK_ENV: development
+      FLASK_DEBUG: '1'
+      HYBRID_FEATURE_FLAG_SOURCE: local-dev
     volumes:
       - ./frontend:/app
       - ./static:/app/static
@@ -101,9 +110,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_DB=legacy_coin_trader_dev
-      - POSTGRES_USER=dev_user
-      - POSTGRES_PASSWORD=dev_password
+      POSTGRES_DB: legacy_coin_trader_dev
+      POSTGRES_USER: dev_user
+      POSTGRES_PASSWORD: dev_password
     volumes:
       - postgres_dev_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,15 +18,16 @@ services:
     volumes:
       - redis_prod_data:/data
     environment:
-      - REDIS_MAXMEMORY=256mb
-      - REDIS_MAXMEMORY_POLICY=allkeys-lru
+      REDIS_MAXMEMORY: 256mb
+      REDIS_MAXMEMORY_POLICY: allkeys-lru
 
   # Production overrides for API Gateway
   api-gateway:
     environment:
-      - GATEWAY_LOG_LEVEL=INFO
-      - GATEWAY_RATE_LIMIT_REQUESTS=1000
-      - GATEWAY_RATE_LIMIT_WINDOW=60
+      GATEWAY_LOG_LEVEL: INFO
+      GATEWAY_RATE_LIMIT_REQUESTS: 1000
+      GATEWAY_RATE_LIMIT_WINDOW: 60
+      HYBRID_FEATURE_FLAG_SOURCE: prod-config
     deploy:
       resources:
         limits:
@@ -51,9 +52,9 @@ services:
   # Production overrides for Trading Engine
   trading-engine:
     environment:
-      - TRADING_ENGINE_LOG_LEVEL=INFO
-      - TRADING_ENGINE_CYCLE_INTERVAL=120
-      - TRADING_ENGINE_BATCH_SIZE=25
+      TRADING_ENGINE_LOG_LEVEL: INFO
+      TRADING_ENGINE_CYCLE_INTERVAL: 120
+      TRADING_ENGINE_BATCH_SIZE: 25
     deploy:
       resources:
         limits:
@@ -78,8 +79,8 @@ services:
   # Production overrides for Market Data Service
   market-data:
     environment:
-      - MARKET_DATA_LOG_LEVEL=INFO
-      - MARKET_DATA_CACHE_SIZE=1000
+      MARKET_DATA_LOG_LEVEL: INFO
+      MARKET_DATA_CACHE_SIZE: 1000
     deploy:
       resources:
         limits:
@@ -104,8 +105,8 @@ services:
   # Production overrides for Portfolio Service
   portfolio:
     environment:
-      - PORTFOLIO_LOG_LEVEL=INFO
-      - PORTFOLIO_BACKUP_INTERVAL=3600
+      PORTFOLIO_LOG_LEVEL: INFO
+      PORTFOLIO_BACKUP_INTERVAL: 3600
     deploy:
       resources:
         limits:
@@ -130,8 +131,8 @@ services:
   # Production overrides for Strategy Engine
   strategy-engine:
     environment:
-      - STRATEGY_ENGINE_LOG_LEVEL=INFO
-      - STRATEGY_ENGINE_MODEL_CACHE_SIZE=100
+      STRATEGY_ENGINE_LOG_LEVEL: INFO
+      STRATEGY_ENGINE_MODEL_CACHE_SIZE: 100
     deploy:
       resources:
         limits:
@@ -156,8 +157,8 @@ services:
   # Production overrides for Token Discovery Service
   token-discovery:
     environment:
-      - TOKEN_DISCOVERY_LOG_LEVEL=INFO
-      - TOKEN_DISCOVERY_MAX_CONCURRENT_SCANS=5
+      TOKEN_DISCOVERY_LOG_LEVEL: INFO
+      TOKEN_DISCOVERY_MAX_CONCURRENT_SCANS: 5
     deploy:
       resources:
         limits:
@@ -182,9 +183,9 @@ services:
   # Production overrides for Execution Service
   execution:
     environment:
-      - EXECUTION_LOG_LEVEL=INFO
-      - EXECUTION_MAX_RETRIES=3
-      - EXECUTION_RATE_LIMIT_ENABLED=true
+      EXECUTION_LOG_LEVEL: INFO
+      EXECUTION_MAX_RETRIES: 3
+      EXECUTION_RATE_LIMIT_ENABLED: 'true'
     deploy:
       resources:
         limits:
@@ -209,8 +210,8 @@ services:
   # Production overrides for Monitoring Service
   monitoring:
     environment:
-      - MONITORING_LOG_LEVEL=INFO
-      - MONITORING_METRICS_RETENTION=7d
+      MONITORING_LOG_LEVEL: INFO
+      MONITORING_METRICS_RETENTION: 7d
     deploy:
       resources:
         limits:
@@ -235,8 +236,8 @@ services:
   # Production overrides for Frontend
   frontend:
     environment:
-      - FLASK_ENV=production
-      - FLASK_DEBUG=0
+      FLASK_ENV: production
+      FLASK_DEBUG: '0'
     deploy:
       resources:
         limits:
@@ -262,9 +263,9 @@ services:
   postgres:
     image: postgres:15-alpine
     environment:
-      - POSTGRES_DB=legacy_coin_trader_prod
-      - POSTGRES_USER=${DB_USER:-prod_user}
-      - POSTGRES_PASSWORD=${DB_PASSWORD:-change_me_in_production}
+      POSTGRES_DB: legacy_coin_trader_prod
+      POSTGRES_USER: ${DB_USER:-prod_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-change_me_in_production}
     volumes:
       - postgres_prod_data:/var/lib/postgresql/data
       - ./db/init:/docker-entrypoint-initdb.d

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,9 +11,10 @@ services:
 
   api-gateway:
     environment:
-      - GATEWAY_LOG_LEVEL=DEBUG
-      - GATEWAY_RATE_LIMIT_REQUESTS=10000  # Higher limits for testing
-      - GATEWAY_RATE_LIMIT_WINDOW=60
+      GATEWAY_LOG_LEVEL: DEBUG
+      GATEWAY_RATE_LIMIT_REQUESTS: 10000  # Higher limits for testing
+      GATEWAY_RATE_LIMIT_WINDOW: 60
+      HYBRID_FEATURE_FLAG_SOURCE: test-suite
     volumes:
       - ./services/api_gateway:/app
     healthcheck:
@@ -25,9 +26,9 @@ services:
 
   trading-engine:
     environment:
-      - TRADING_ENGINE_LOG_LEVEL=DEBUG
-      - TRADING_ENGINE_CYCLE_INTERVAL=30  # Faster cycles for testing
-      - TRADING_ENGINE_BATCH_SIZE=10
+      TRADING_ENGINE_LOG_LEVEL: DEBUG
+      TRADING_ENGINE_CYCLE_INTERVAL: 30  # Faster cycles for testing
+      TRADING_ENGINE_BATCH_SIZE: 10
     volumes:
       - ./services/trading_engine:/app/services/trading_engine
       - ./services/interface_layer:/app/services/interface_layer
@@ -40,8 +41,8 @@ services:
 
   market-data:
     environment:
-      - MARKET_DATA_LOG_LEVEL=DEBUG
-      - MARKET_DATA_CACHE_SIZE=50  # Smaller cache for testing
+      MARKET_DATA_LOG_LEVEL: DEBUG
+      MARKET_DATA_CACHE_SIZE: 50  # Smaller cache for testing
     volumes:
       - ./services/market_data:/app
       - ./crypto_bot:/app/crypto_bot
@@ -54,8 +55,8 @@ services:
 
   portfolio:
     environment:
-      - PORTFOLIO_LOG_LEVEL=DEBUG
-      - PORTFOLIO_PAPER_TRADING=true  # Force paper trading for tests
+      PORTFOLIO_LOG_LEVEL: DEBUG
+      PORTFOLIO_PAPER_TRADING: 'true'  # Force paper trading for tests
     volumes:
       - ./services/portfolio:/app
       - ./crypto_bot:/app/crypto_bot
@@ -68,7 +69,7 @@ services:
 
   strategy-engine:
     environment:
-      - STRATEGY_ENGINE_LOG_LEVEL=DEBUG
+      STRATEGY_ENGINE_LOG_LEVEL: DEBUG
     volumes:
       - ./services/strategy_engine:/app
       - ./crypto_bot:/app/crypto_bot
@@ -81,8 +82,8 @@ services:
 
   token-discovery:
     environment:
-      - TOKEN_DISCOVERY_LOG_LEVEL=DEBUG
-      - TOKEN_DISCOVERY_SCAN_INTERVAL=10  # Faster scanning for tests
+      TOKEN_DISCOVERY_LOG_LEVEL: DEBUG
+      TOKEN_DISCOVERY_SCAN_INTERVAL: 10  # Faster scanning for tests
     volumes:
       - ./services/token_discovery:/app
       - ./crypto_bot:/app/crypto_bot
@@ -95,8 +96,8 @@ services:
 
   execution:
     environment:
-      - EXECUTION_LOG_LEVEL=DEBUG
-      - EXECUTION_DRY_RUN=true  # Force dry run for tests
+      EXECUTION_LOG_LEVEL: DEBUG
+      EXECUTION_DRY_RUN: 'true'  # Force dry run for tests
     volumes:
       - ./services/execution:/app
       - ./crypto_bot:/app/crypto_bot
@@ -109,7 +110,7 @@ services:
 
   monitoring:
     environment:
-      - MONITORING_LOG_LEVEL=DEBUG
+      MONITORING_LOG_LEVEL: DEBUG
     volumes:
       - ./services/monitoring:/app
       - ./crypto_bot:/app/crypto_bot
@@ -122,8 +123,8 @@ services:
 
   frontend:
     environment:
-      - FLASK_ENV=development
-      - FLASK_DEBUG=1
+      FLASK_ENV: development
+      FLASK_DEBUG: '1'
     volumes:
       - ./frontend:/app
       - ./static:/app/static
@@ -163,8 +164,8 @@ services:
       - ./tests/e2e:/app/tests
       - ./e2e_test_results.json:/app/e2e_test_results.json
     environment:
-      - API_GATEWAY_URL=http://api-gateway:8000
-      - TEST_TIMEOUT=300  # 5 minutes timeout
+      API_GATEWAY_URL: http://api-gateway:8000
+      TEST_TIMEOUT: 300  # 5 minutes timeout
     command: ["python", "/app/tests/test_e2e_framework.py"]
     deploy:
       restart_policy:
@@ -175,9 +176,9 @@ services:
   test-postgres:
     image: postgres:15-alpine
     environment:
-      - POSTGRES_DB=legacy_coin_trader_test
-      - POSTGRES_USER=test_user
-      - POSTGRES_PASSWORD=test_password
+      POSTGRES_DB: legacy_coin_trader_test
+      POSTGRES_USER: test_user
+      POSTGRES_PASSWORD: test_password
     volumes:
       - test_postgres_data:/var/lib/postgresql/data
       - ./tests/db/init:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 ---
 version: '3.8'
 
+x-hybrid-env: &hybrid-env
+  HYBRID_MODE_ENABLED: ${HYBRID_MODE_ENABLED:-false}
+  LEGACY_READ_ENABLED: ${LEGACY_READ_ENABLED:-true}
+  DUAL_WRITE_STRATEGY: ${DUAL_WRITE_STRATEGY:-mirror}
+  HYBRID_READ_STRATEGY: ${HYBRID_READ_STRATEGY:-compare}
+  CUTOVER_TARGET_TIMESTAMP: ${CUTOVER_TARGET_TIMESTAMP:-}
+  CUTOVER_COMPLETED: ${CUTOVER_COMPLETED:-false}
+  CUTOVER_GUARDRAIL_ENABLED: ${CUTOVER_GUARDRAIL_ENABLED:-true}
+  MIGRATION_DRIFT_TOLERANCE: ${MIGRATION_DRIFT_TOLERANCE:-0.0}
+  LEGACY_API_HOST: ${LEGACY_API_HOST:-legacy-monolith}
+  LEGACY_API_PORT: ${LEGACY_API_PORT:-8080}
+  MODERN_API_HOST: ${MODERN_API_HOST:-api-gateway}
+  MODERN_API_PORT: ${MODERN_API_PORT:-8000}
+
 services:
   # Shared Redis instance for caching and service discovery
   redis:
@@ -16,6 +30,53 @@ services:
       timeout: 3s
       retries: 3
 
+  legacy-postgres:
+    image: postgres:15-alpine
+    profiles:
+      - legacy
+      - hybrid
+    environment:
+      POSTGRES_DB: legacy_coin_trader
+      POSTGRES_USER: legacy_user
+      POSTGRES_PASSWORD: legacy_password
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U legacy_user -d legacy_coin_trader"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - legacy_pg_data:/var/lib/postgresql/data
+
+  legacy-monolith:
+    image: ${LEGACY_MONOLITH_IMAGE:-ghcr.io/example/legacycointrader/monolith:1.0}
+    profiles:
+      - legacy
+      - hybrid
+    ports:
+      - "8080:8080"
+    depends_on:
+      redis:
+        condition: service_healthy
+      legacy-postgres:
+        condition: service_healthy
+    environment:
+      <<: *hybrid-env
+      LEGACY_DATABASE_HOST: legacy-postgres
+      LEGACY_DATABASE_PORT: 5432
+      LEGACY_CONFIG_PATH: /opt/legacy/config/config.yaml
+    volumes:
+      - ./config:/opt/legacy/config:ro
+      - ./tools/migration:/opt/legacy/migration:ro
+    command: ${LEGACY_MONOLITH_COMMAND:-python /opt/legacy/app/start_bot.py auto}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s
+
   # API Gateway - Entry point for all requests
   api-gateway:
     build: ./services/api_gateway
@@ -25,8 +86,12 @@ services:
       redis:
         condition: service_healthy
     environment:
-      - GATEWAY_REDIS_HOST=redis
-      - GATEWAY_REDIS_PORT=6379
+      <<: *hybrid-env
+      GATEWAY_REDIS_HOST: redis
+      GATEWAY_REDIS_PORT: 6379
+      LEGACY_SERVICE_BASE_URL: ${LEGACY_SERVICE_BASE_URL:-http://legacy-monolith:8080}
+      MODERN_SERVICE_BASE_URL: ${MODERN_SERVICE_BASE_URL:-http://api-gateway:8000}
+      HYBRID_FEATURE_FLAG_SOURCE: ${HYBRID_FEATURE_FLAG_SOURCE:-config}
     volumes:
       - ./services/api_gateway:/app
     healthcheck:
@@ -49,10 +114,12 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - TRADING_ENGINE_REDIS_HOST=redis
-      - TRADING_ENGINE_REDIS_PORT=6379
-      - TRADING_ENGINE_API_GATEWAY_HOST=api-gateway
-      - TRADING_ENGINE_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      TRADING_ENGINE_REDIS_HOST: redis
+      TRADING_ENGINE_REDIS_PORT: 6379
+      TRADING_ENGINE_API_GATEWAY_HOST: api-gateway
+      TRADING_ENGINE_API_GATEWAY_PORT: 8000
+      TRADING_ENGINE_LEGACY_BASE_URL: ${TRADING_ENGINE_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/trading_engine:/app/services/trading_engine
       - ./services/interface_layer:/app/services/interface_layer
@@ -74,10 +141,12 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - MARKET_DATA_REDIS_HOST=redis
-      - MARKET_DATA_REDIS_PORT=6379
-      - MARKET_DATA_API_GATEWAY_HOST=api-gateway
-      - MARKET_DATA_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      MARKET_DATA_REDIS_HOST: redis
+      MARKET_DATA_REDIS_PORT: 6379
+      MARKET_DATA_API_GATEWAY_HOST: api-gateway
+      MARKET_DATA_API_GATEWAY_PORT: 8000
+      MARKET_DATA_LEGACY_BASE_URL: ${MARKET_DATA_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/market_data:/app
       - ./crypto_bot:/app/crypto_bot  # Mount existing crypto_bot for shared utilities
@@ -99,10 +168,12 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - PORTFOLIO_REDIS_HOST=redis
-      - PORTFOLIO_REDIS_PORT=6379
-      - PORTFOLIO_API_GATEWAY_HOST=api-gateway
-      - PORTFOLIO_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      PORTFOLIO_REDIS_HOST: redis
+      PORTFOLIO_REDIS_PORT: 6379
+      PORTFOLIO_API_GATEWAY_HOST: api-gateway
+      PORTFOLIO_API_GATEWAY_PORT: 8000
+      PORTFOLIO_LEGACY_BASE_URL: ${PORTFOLIO_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/portfolio:/app
       - ./crypto_bot:/app/crypto_bot
@@ -126,12 +197,14 @@ services:
       market-data:
         condition: service_healthy
     environment:
-      - STRATEGY_ENGINE_REDIS_HOST=redis
-      - STRATEGY_ENGINE_REDIS_PORT=6379
-      - STRATEGY_ENGINE_API_GATEWAY_HOST=api-gateway
-      - STRATEGY_ENGINE_API_GATEWAY_PORT=8000
-      - STRATEGY_ENGINE_MARKET_DATA_HOST=market-data
-      - STRATEGY_ENGINE_MARKET_DATA_PORT=8002
+      <<: *hybrid-env
+      STRATEGY_ENGINE_REDIS_HOST: redis
+      STRATEGY_ENGINE_REDIS_PORT: 6379
+      STRATEGY_ENGINE_API_GATEWAY_HOST: api-gateway
+      STRATEGY_ENGINE_API_GATEWAY_PORT: 8000
+      STRATEGY_ENGINE_MARKET_DATA_HOST: market-data
+      STRATEGY_ENGINE_MARKET_DATA_PORT: 8002
+      STRATEGY_ENGINE_LEGACY_BASE_URL: ${STRATEGY_ENGINE_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/strategy_engine:/app
       - ./crypto_bot:/app/crypto_bot
@@ -155,10 +228,12 @@ services:
       market-data:
         condition: service_healthy
     environment:
-      - TOKEN_DISCOVERY_REDIS_HOST=redis
-      - TOKEN_DISCOVERY_REDIS_PORT=6379
-      - TOKEN_DISCOVERY_API_GATEWAY_HOST=api-gateway
-      - TOKEN_DISCOVERY_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      TOKEN_DISCOVERY_REDIS_HOST: redis
+      TOKEN_DISCOVERY_REDIS_PORT: 6379
+      TOKEN_DISCOVERY_API_GATEWAY_HOST: api-gateway
+      TOKEN_DISCOVERY_API_GATEWAY_PORT: 8000
+      TOKEN_DISCOVERY_LEGACY_BASE_URL: ${TOKEN_DISCOVERY_LEGACY_BASE_URL:-http://legacy-monolith:8080}
       - TOKEN_DISCOVERY_MARKET_DATA_HOST=market-data
       - TOKEN_DISCOVERY_MARKET_DATA_PORT=8002
     volumes:
@@ -182,10 +257,12 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - EXECUTION_REDIS_HOST=redis
-      - EXECUTION_REDIS_PORT=6379
-      - EXECUTION_API_GATEWAY_HOST=api-gateway
-      - EXECUTION_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      EXECUTION_REDIS_HOST: redis
+      EXECUTION_REDIS_PORT: 6379
+      EXECUTION_API_GATEWAY_HOST: api-gateway
+      EXECUTION_API_GATEWAY_PORT: 8000
+      EXECUTION_LEGACY_BASE_URL: ${EXECUTION_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/execution:/app
       - ./crypto_bot:/app/crypto_bot
@@ -208,10 +285,12 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - MONITORING_REDIS_HOST=redis
-      - MONITORING_REDIS_PORT=6379
-      - MONITORING_API_GATEWAY_HOST=api-gateway
-      - MONITORING_API_GATEWAY_PORT=8000
+      <<: *hybrid-env
+      MONITORING_REDIS_HOST: redis
+      MONITORING_REDIS_PORT: 6379
+      MONITORING_API_GATEWAY_HOST: api-gateway
+      MONITORING_API_GATEWAY_PORT: 8000
+      MONITORING_LEGACY_BASE_URL: ${MONITORING_LEGACY_BASE_URL:-http://legacy-monolith:8080}
     volumes:
       - ./services/monitoring:/app
       - ./crypto_bot:/app/crypto_bot
@@ -232,8 +311,10 @@ services:
       api-gateway:
         condition: service_healthy
     environment:
-      - FLASK_ENV=development
-      - API_GATEWAY_URL=http://api-gateway:8000
+      <<: *hybrid-env
+      FLASK_ENV: development
+      API_GATEWAY_URL: http://api-gateway:8000
+      LEGACY_BACKEND_URL: ${LEGACY_BACKEND_URL:-http://legacy-monolith:8080}
     volumes:
       - ./frontend:/app
       - ./static:/app/static
@@ -247,6 +328,8 @@ services:
 
 volumes:
   redis_data:
+    driver: local
+  legacy_pg_data:
     driver: local
 
 networks:

--- a/docs/hybrid_migration_playbook.md
+++ b/docs/hybrid_migration_playbook.md
@@ -1,0 +1,152 @@
+# LegacyCoinTrader Hybrid Migration Playbook
+
+## Overview
+
+This playbook describes how to migrate tenant data from LegacyCoinTrader 1.0 into the multi-tenant microservices platform while
+operating both stacks in parallel. It complements the new automation delivered in `tools/migration` and the hybrid deployment
+options added to `docker-compose` and the Helm charts.
+
+Key objectives:
+
+* Maintain customer availability throughout the transition.
+* Provide a reversible migration with clearly defined cutover gates.
+* Give the Change Advisory Board (CAB) structured feedback checkpoints and reporting artefacts.
+
+---
+
+## Phased Rollout Plan
+
+| Phase | Target Duration | Scope | CAB Checkpoint | Hybrid Toggles |
+| ----- | --------------- | ----- | -------------- | -------------- |
+| **Preparation** | Week 0 | Baseline health checks, capture tenant inventory, back up legacy DB | CAB review of migration plan and risk register | All hybrid flags off |
+| **Shadow Read** | Week 1 | Enable `HYBRID_MODE_ENABLED` for read-only mirroring on pilot tenants | CAB sign-off on data parity metrics (run `tools/migration/tenant_migration.py audit`) | `HYBRID_MODE_ENABLED=true`, `DUAL_WRITE_STRATEGY=legacy-primary`, `HYBRID_READ_STRATEGY=compare` |
+| **Dual Write** | Weeks 2–3 | Expand to majority of tenants with dual write enabled, monitor drift | Weekly CAB checkpoint with diff report and reconciliation sign-off | `DUAL_WRITE_STRATEGY=mirror`, `MIGRATION_DRIFT_TOLERANCE=<per tenant>` |
+| **Cutover Read** | Week 4 | Flip read preference to microservices, legacy remains as safety net | CAB go/no-go with rollback decision tree | `HYBRID_READ_STRATEGY=prefer-modern`, `CUTOVER_COMPLETED=false` |
+| **Final Cutover** | Week 5 | Disable legacy writes, freeze new onboarding into 1.0 | Emergency CAB call to confirm stabilisation | `CUTOVER_COMPLETED=true`, `CUTOVER_GUARDRAIL_ENABLED=true` |
+| **Decommission** | Week 6+ | Archive legacy data, dismantle hybrid infrastructure | CAB closure report | Hybrid flags removed |
+
+Operational guidance:
+
+* **Tenant Cohorts:** Start with low-volume tenants, graduate to strategic accounts, then the long-tail. Maintain a per-cohort
+  rollback window (24–48 hours) before progressing.
+* **Data Audits:** After each cohort migration, run `make migration-audit` (or directly invoke the audit CLI) and attach the
+  generated JSON to the CAB minutes.
+* **Performance Monitors:** Use the new docker-compose hybrid environment variables to surface dashboards that report dual-write
+  latency and drift counters (`MIGRATION_DRIFT_TOLERANCE`).
+
+---
+
+## Rollback Procedures
+
+1. **Immediate Drift Response**
+   * Triggered when `tools/migration/tenant_migration.py audit --fail-on-drift` exits non-zero or when the dual-read shim raises a
+     guardrail exception.
+   * Actions:
+     * Set `CUTOVER_COMPLETED=false` and `DUAL_WRITE_STRATEGY=legacy-only` via Helm values / docker-compose overrides.
+     * Revert tenant routing in the API Gateway (`LEGACY_SERVICE_BASE_URL` environment variable) to point exclusively at 1.0.
+     * Notify CAB and affected customer segments with the “Incident Head-Up” template below.
+
+2. **Controlled Rollback (Cohort)**
+   * Roll back the most recent cohort by replaying the migration plan in reverse:
+     1. Pause ingestion for the impacted tenants (`DualWriteStrategy.LEGACY_ONLY`).
+     2. Run the schema migrator with `generate-migration-plan` to capture undo scripts (`tenant_migration.py migration-plan ...`).
+     3. Execute the rollback SQL against the multi-tenant schema.
+     4. Run the audit in verification mode to confirm the legacy dataset is authoritative.
+
+3. **Full Rollback / Abort**
+   * If CAB directs a full abort, execute the following within a change window:
+     * `docker compose down` (or Helm rollback) for all microservices.
+     * Redeploy the legacy monolith via `start_integrated.sh --legacy-only --cutover-ready` (restores legacy-only mode).
+     * Archive hybrid configuration artefacts and submit a CAB incident closure report.
+
+Monitoring and alerting updates:
+
+* Both start scripts export hybrid environment variables so runtime logs clearly state the current strategy and tolerance.
+* The dual-read shim emits audit callbacks that can be wired to PagerDuty or Slack for rapid detection.
+
+---
+
+## CAB Feedback Loop
+
+* **Weekly CAB Pack:**
+  * Migration status dashboard (number of tenants migrated, drift detected, outstanding tasks).
+  * Data integrity audit summary (use `tools/migration/post_migration_validator.py` outputs).
+  * Feature flag matrix pulled from `tenant_migration.py flags` for transparency.
+
+* **Emergency CAB Call Criteria:**
+  * Any failed audit with `fail-on-drift`.
+  * More than 10% latency regression on dual writes.
+  * Customer-facing incident attributed to hybrid routing.
+
+* **Decision Log:** Store approvals and rollbacks in `docs/cab_decision_log.md` (create if absent) with direct references to the
+  generated audit reports.
+
+---
+
+## Customer Communication Templates
+
+### 1. Migration Heads-Up (T-7 Days)
+
+```
+Subject: Upcoming LegacyCoinTrader platform enhancements
+
+Hi {{customer_name}},
+
+We are preparing to migrate your LegacyCoinTrader workspace to our new multi-tenant infrastructure during the week of {{date}}.
+Trading and monitoring services will remain available; the migration runs in a hybrid mode where we verify all data in parallel.
+
+Key points:
+- No action is required on your side.
+- We will send a completion notice once the cutover is finalised.
+- Support remains available 24/7 via the usual channels.
+
+If you have CAB review requirements, please share them so we can align schedules.
+
+Thank you,
+LegacyCoinTrader Operations
+```
+
+### 2. Incident Heads-Up (Drift Detected)
+
+```
+Subject: Temporary failback to LegacyCoinTrader 1.0
+
+Hi {{customer_name}},
+
+During our hybrid migration validation we detected a data inconsistency affecting your tenant. We have switched trading reads back
+to LegacyCoinTrader 1.0 while we reconcile the dataset. There is no impact to order execution.
+
+What happens next:
+- Our engineers will re-run the migration validator and share the reconciliation summary.
+- We will notify you before re-enabling the multi-tenant path.
+
+Please reach out if you require additional reporting for your CAB.
+
+Regards,
+LegacyCoinTrader Operations
+```
+
+### 3. Cutover Confirmation
+
+```
+Subject: LegacyCoinTrader migration complete
+
+Hi {{customer_name}},
+
+Your tenant has been successfully migrated to the new multi-tenant platform. The legacy stack is now in read-only standby mode and
+will be retired after {{retirement_window}}. All monitoring dashboards and API endpoints remain unchanged.
+
+If you observe any discrepancies please contact support referencing ticket “Hybrid-Cutover”.
+
+Best,
+LegacyCoinTrader Operations
+```
+
+---
+
+## Artefact Checklist
+
+* ✅ SQL schema and migration plans generated via `tools/migration/tenant_migration.py`.
+* ✅ Config translation outputs stored under `tools/migration/transformed_configs/` or a secure bucket.
+* ✅ Automated audits integrated into CI with `make migration-audit` (see Makefile target).
+* ✅ CAB feedback artefacts archived in the `/docs` directory alongside this playbook.

--- a/start_integrated.sh
+++ b/start_integrated.sh
@@ -13,14 +13,93 @@ NC='\033[0m' # No Color
 
 WORKING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --hybrid                Enable dual-run mode (legacy + microservices)
+  --legacy-only           Start only the legacy stack (default behaviour)
+  --microservices-only    Start only the microservices via docker-compose
+  --compose               Launch docker-compose stack before starting legacy services
+  --read-strategy <mode>  Dual read strategy (compare, prefer-legacy, prefer-modern)
+  --write-strategy <mode> Dual write strategy (mirror, legacy-primary, modern-primary, legacy-only, modern-only)
+  --cutover-ready         Mark the deployment as post-cutover (disables legacy writes)
+  --drift-tolerance <n>   Numeric drift tolerance (default: 0.0)
+  -h, --help              Show this help message
+USAGE
+}
+
+HYBRID_MODE=false
+MICROSERVICE_ONLY=false
+START_LEGACY=true
+START_COMPOSE=false
+READ_STRATEGY="compare"
+WRITE_STRATEGY="mirror"
+CUTOVER_READY=false
+DRIFT_TOLERANCE="0.0"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hybrid)
+            HYBRID_MODE=true
+            START_LEGACY=true
+            MICROSERVICE_ONLY=false
+            START_COMPOSE=true
+            ;;
+        --legacy-only)
+            START_LEGACY=true
+            HYBRID_MODE=false
+            MICROSERVICE_ONLY=false
+            ;;
+        --microservices-only)
+            MICROSERVICE_ONLY=true
+            START_LEGACY=false
+            START_COMPOSE=true
+            ;;
+        --compose)
+            START_COMPOSE=true
+            ;;
+        --read-strategy)
+            READ_STRATEGY="$2"
+            shift || true
+            ;;
+        --write-strategy)
+            WRITE_STRATEGY="$2"
+            shift || true
+            ;;
+        --cutover-ready)
+            CUTOVER_READY=true
+            ;;
+        --drift-tolerance)
+            DRIFT_TOLERANCE="$2"
+            shift || true
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 echo -e "${BLUE}🚀 Starting LegacyCoinTrader - Complete System${NC}"
 echo -e "${BLUE}$(printf '%.0s=' {1..60})${NC}"
-echo -e "${GREEN}📈 OHLCV Fetching + 🤖 Trading Bot + 🌐 Web Dashboard + 🖥️ Browser${NC}"
+if [[ "$HYBRID_MODE" == "true" ]]; then
+    echo -e "${GREEN}🤝 Hybrid mode enabled - orchestrating legacy + microservices${NC}"
+else
+    echo -e "${GREEN}📈 OHLCV Fetching + 🤖 Trading Bot + 🌐 Web Dashboard${NC}"
+fi
 echo -e "${BLUE}$(printf '%.0s=' {1..60})${NC}"
 
 # Check if we're already running
-if pgrep -f "start_bot.py\|crypto_bot.main\|frontend.app" > /dev/null 2>&1; then
-    echo -e "${YELLOW}⚠️  System appears to already be running${NC}"
+if pgrep -f "start_bot.py\|crypto_bot.main\|frontend.app" > /dev/null 2>&1 && [[ "$START_LEGACY" == "true" ]]; then
+    echo -e "${YELLOW}⚠️  Legacy services appear to already be running${NC}"
     echo "   To stop: Ctrl+C or use './stop_integrated.sh'"
     echo "   Check processes: ps aux | grep -E '(start_bot.py|crypto_bot|frontend)'"
     exit 1
@@ -30,10 +109,15 @@ fi
 cleanup() {
     echo ""
     echo -e "${YELLOW}🛑 Shutting down all services...${NC}"
-    pkill -f "start_bot.py" || true
-    pkill -f "crypto_bot.main" || true
-    pkill -f "frontend.app" || true
-    pkill -f "telegram_ctl.py" || true
+    if [[ "$MICROSERVICE_ONLY" == "true" || "$HYBRID_MODE" == "true" || "$START_COMPOSE" == "true" ]]; then
+        docker-compose down >/dev/null 2>&1 || true
+    fi
+    if [[ "$START_LEGACY" == "true" ]]; then
+        pkill -f "start_bot.py" || true
+        pkill -f "crypto_bot.main" || true
+        pkill -f "frontend.app" || true
+        pkill -f "telegram_ctl.py" || true
+    fi
     echo -e "${GREEN}✅ All services stopped${NC}"
     exit 0
 }
@@ -44,24 +128,56 @@ trap cleanup SIGINT SIGTERM
 # Clean up any stale PID files
 rm -f *.pid 2>/dev/null || true
 
-# Verify .env file exists
-if [[ ! -f ".env" ]]; then
+# Configure hybrid feature flags
+if [[ "$HYBRID_MODE" == "true" || "$START_COMPOSE" == "true" ]]; then
+    export HYBRID_MODE_ENABLED=$([[ "$HYBRID_MODE" == "true" ]] && echo "true" || echo "false")
+    if [[ "$READ_STRATEGY" == "prefer-legacy" ]]; then
+        export LEGACY_READ_ENABLED=true
+    elif [[ "$READ_STRATEGY" == "prefer-modern" ]]; then
+        export LEGACY_READ_ENABLED=false
+    else
+        export LEGACY_READ_ENABLED=$([[ "$HYBRID_MODE" == "true" ]] && echo "true" || echo "false")
+    fi
+    export HYBRID_READ_STRATEGY="$READ_STRATEGY"
+    export DUAL_WRITE_STRATEGY="$WRITE_STRATEGY"
+    export CUTOVER_COMPLETED=$([[ "$CUTOVER_READY" == "true" ]] && echo "true" || echo "false")
+    export CUTOVER_GUARDRAIL_ENABLED=true
+    export MIGRATION_DRIFT_TOLERANCE="$DRIFT_TOLERANCE"
+    export HYBRID_FEATURE_FLAG_SOURCE="start_integrated.sh"
+fi
+
+# Verify .env file exists when legacy services are needed
+if [[ "$START_LEGACY" == "true" ]] && [[ ! -f ".env" ]]; then
     echo -e "${RED}❌ Error: .env file not found!${NC}"
     echo "   Please create a .env file with your API keys"
     echo "   See .env.example for the required format"
     exit 1
 fi
 
-# Start the complete system
-echo "🎯 Launching complete LegacyCoinTrader system..."
-echo ""
+if [[ "$START_COMPOSE" == "true" ]]; then
+    echo -e "${BLUE}🔧 Launching docker-compose stack...${NC}"
+    docker-compose up -d
+fi
 
-# Set environment variables for proper startup
-export AUTO_START_TRADING=1
-export NON_INTERACTIVE=1
+if [[ "$MICROSERVICE_ONLY" == "true" ]]; then
+    echo -e "${GREEN}✅ Microservices stack started in isolation${NC}"
+    echo -e "${YELLOW}ℹ️  Legacy services were not started (microservices-only mode)${NC}"
+    exit 0
+fi
 
-# Start the integrated system
-python3 start_bot.py auto
+if [[ "$START_LEGACY" == "true" ]]; then
+    echo "🎯 Launching legacy LegacyCoinTrader system..."
+    echo ""
 
-echo ""
-echo -e "${GREEN}✅ Complete system has stopped${NC}"
+    export AUTO_START_TRADING=1
+    export NON_INTERACTIVE=1
+
+    python3 start_bot.py auto
+
+    echo ""
+    echo -e "${GREEN}✅ Legacy system has stopped${NC}"
+fi
+
+if [[ "$HYBRID_MODE" == "true" ]]; then
+    echo -e "${GREEN}✅ Hybrid runtime finished. Compose services remain running.${NC}"
+fi

--- a/tests/fixtures/migration/base_config.yaml
+++ b/tests/fixtures/migration/base_config.yaml
@@ -1,0 +1,7 @@
+version: '1.0'
+risk:
+  max_position: 5
+  stop_loss_pct: 0.05
+exchanges:
+  primary: binance
+  secondary: kraken

--- a/tests/fixtures/migration/feature_flags.yaml
+++ b/tests/fixtures/migration/feature_flags.yaml
@@ -1,0 +1,4 @@
+feature_flags:
+  HYBRID_MODE_ENABLED: true
+  LEGACY_READ_ENABLED: false
+  DUAL_WRITE_STRATEGY: mirror

--- a/tests/fixtures/migration/legacy_schema.yaml
+++ b/tests/fixtures/migration/legacy_schema.yaml
@@ -1,0 +1,33 @@
+tables:
+  - name: accounts
+    tenant_lookup_key: account_id
+    columns:
+      - name: account_id
+        type: UUID
+        primary_key: true
+        nullable: false
+      - name: user_id
+        type: UUID
+        nullable: false
+      - name: balance
+        type: NUMERIC(18,8)
+        nullable: false
+  - name: trades
+    tenant_lookup_key: user_id
+    columns:
+      - name: id
+        type: UUID
+        primary_key: true
+        nullable: false
+      - name: user_id
+        type: UUID
+        nullable: false
+      - name: symbol
+        type: TEXT
+        nullable: false
+      - name: qty
+        type: NUMERIC(18,8)
+        nullable: false
+      - name: price
+        type: NUMERIC(18,8)
+        nullable: false

--- a/tests/fixtures/migration/legacy_snapshot.json
+++ b/tests/fixtures/migration/legacy_snapshot.json
@@ -1,0 +1,20 @@
+{
+  "tenants": {
+    "tenant-a": {
+      "balances": [
+        {"id": "btc", "asset": "BTC", "available": 1.25, "reserved": 0.05},
+        {"id": "eth", "asset": "ETH", "available": 12.0, "reserved": 1.0}
+      ],
+      "positions": {
+        "pos-1": {"symbol": "BTC-USD", "size": 0.5, "entry_price": 30000.0},
+        "pos-2": {"symbol": "ETH-USD", "size": 10.0, "entry_price": 1800.0}
+      }
+    },
+    "tenant-b": {
+      "balances": [
+        {"id": "sol", "asset": "SOL", "available": 250.0, "reserved": 0.0}
+      ],
+      "positions": {}
+    }
+  }
+}

--- a/tests/fixtures/migration/modern_snapshot.json
+++ b/tests/fixtures/migration/modern_snapshot.json
@@ -1,0 +1,20 @@
+{
+  "tenants": {
+    "tenant-a": {
+      "balances": [
+        {"id": "btc", "asset": "BTC", "available": 1.25, "reserved": 0.05},
+        {"id": "eth", "asset": "ETH", "available": 12.0, "reserved": 1.0}
+      ],
+      "positions": {
+        "pos-1": {"symbol": "BTC-USD", "size": 0.5, "entry_price": 30000.0},
+        "pos-2": {"symbol": "ETH-USD", "size": 10.0, "entry_price": 1800.0}
+      }
+    },
+    "tenant-b": {
+      "balances": [
+        {"id": "sol", "asset": "SOL", "available": 250.0, "reserved": 0.0}
+      ],
+      "positions": {}
+    }
+  }
+}

--- a/tests/fixtures/migration/tenant_mapping.yaml
+++ b/tests/fixtures/migration/tenant_mapping.yaml
@@ -1,0 +1,10 @@
+feature_flags:
+  HYBRID_MODE_ENABLED: true
+  DUAL_WRITE_STRATEGY: mirror
+tenants:
+  tenant-a:
+    legacy_accounts:
+      - 11111111-1111-1111-1111-111111111111
+      - 22222222-2222-2222-2222-222222222222
+  tenant-b:
+    legacy_account: 33333333-3333-3333-3333-333333333333

--- a/tests/fixtures/migration/tenant_overrides.yaml
+++ b/tests/fixtures/migration/tenant_overrides.yaml
@@ -1,0 +1,11 @@
+tenants:
+  tenant-a:
+    risk:
+      max_position: 10
+    exchanges:
+      primary: coinbase
+  tenant-b:
+    risk:
+      stop_loss_pct: 0.08
+    metadata:
+      region: EU

--- a/tests/test_migration_toolkit.py
+++ b/tests/test_migration_toolkit.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.migration import (
+    ConfigTranslator,
+    DataIntegrityAuditor,
+    DualReadWriteShim,
+    DualWriteStrategy,
+    FeatureFlagState,
+    ReadStrategy,
+    SchemaMigrator,
+)
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "migration"
+
+
+class StubAdapter:
+    def __init__(self) -> None:
+        self.storage = {}
+        self.writes = []
+
+    def read(self, resource: str, tenant_id: str, **_: str):
+        return self.storage.get((resource, tenant_id))
+
+    def write(self, resource: str, tenant_id: str, payload, **_: str):
+        self.storage[(resource, tenant_id)] = payload
+        self.writes.append((resource, tenant_id, payload))
+        return payload
+
+    def delete(self, resource: str, tenant_id: str, **_: str):
+        self.storage.pop((resource, tenant_id), None)
+
+
+def load_fixture(name: str) -> Path:
+    return FIXTURES / name
+
+
+def test_schema_migrator_generates_multi_tenant_sql(tmp_path: Path):
+    migrator = SchemaMigrator.from_file(load_fixture("legacy_schema.yaml"))
+    sql = migrator.generate_schema_sql()
+    assert 'CREATE TABLE IF NOT EXISTS "tenant_accounts"' in sql
+    assert '"tenant_id" UUID NOT NULL' in sql
+    assert 'PRIMARY KEY ("tenant_id", "account_id")' in sql
+    plan = migrator.generate_migration_plan(
+        {
+            "tenant-a": {"legacy_accounts": ["111", "222"]},
+            "tenant-b": {"legacy_account": "333"},
+        }
+    )
+    assert any('INSERT INTO "tenant_accounts"' in statement for statement in plan)
+    assert any("tenant-b" in statement for statement in plan)
+
+
+def test_config_translator_merges_overrides(tmp_path: Path):
+    translator = ConfigTranslator.from_files(
+        load_fixture("base_config.yaml"),
+        load_fixture("tenant_overrides.yaml"),
+        feature_flags_path=load_fixture("feature_flags.yaml"),
+    )
+    translated = translator.translate()
+    assert translated["tenants"]["tenant-a"]["risk"]["max_position"] == 10
+    assert translated["tenants"]["tenant-b"]["risk"]["stop_loss_pct"] == 0.08
+    assert translated["global"]["feature_flags"]["HYBRID_MODE_ENABLED"] is True
+    master, per_tenant = translator.write_outputs(tmp_path)
+    assert master.exists()
+    assert set(per_tenant.keys()) == {"tenant-a", "tenant-b"}
+
+
+def test_dual_read_write_shim_handles_hybrid_reads_and_writes():
+    legacy = StubAdapter()
+    modern = StubAdapter()
+    audit_records = []
+
+    flags = FeatureFlagState(hybrid_mode_enabled=True, prefer_legacy_reads=True)
+    shim = DualReadWriteShim(legacy, modern, feature_flags=flags, audit_callback=audit_records.append)
+
+    legacy.write("balances", "tenant-a", {"available": 10})
+    modern.write("balances", "tenant-a", {"available": 9.5})
+
+    result = shim.read("balances", "tenant-a", strategy=ReadStrategy.COMPARE)
+    assert result == {"available": 9.5}
+    assert audit_records  # mismatch recorded
+
+    shim.write(
+        "balances",
+        "tenant-a",
+        {"available": 11},
+        strategy=DualWriteStrategy.MIRROR,
+    )
+    assert legacy.read("balances", "tenant-a") == {"available": 11}
+    assert modern.read("balances", "tenant-a") == {"available": 11}
+
+    reconciliation = shim.reconcile("balances", "tenant-a")
+    assert reconciliation["drift_detected"] is False
+
+
+def test_data_integrity_auditor_detects_drift(tmp_path: Path):
+    auditor = DataIntegrityAuditor()
+    legacy_snapshot = auditor.load_snapshot(load_fixture("legacy_snapshot.json"))
+    modern_snapshot = auditor.load_snapshot(load_fixture("modern_snapshot.json"))
+    report = auditor.compare(legacy_snapshot, modern_snapshot)
+    assert report.is_successful
+
+    # Introduce drift
+    modern_snapshot["tenants"]["tenant-a"]["balances"][0]["available"] = 1.5
+    drift_report = auditor.compare(legacy_snapshot, modern_snapshot)
+    assert not drift_report.is_successful
+    assert drift_report.mismatched_records == 1
+    report_path = tmp_path / "report.json"
+    drift_report.write(report_path)
+    saved = json.loads(report_path.read_text())
+    assert saved["mismatched_records"] == 1

--- a/tools/migration/__init__.py
+++ b/tools/migration/__init__.py
@@ -1,0 +1,24 @@
+"""Migration utilities for LegacyCoinTrader hybrid deployments."""
+
+from .schema_migrator import ColumnDefinition, SchemaMigrator, TableDefinition
+from .config_translator import ConfigTranslator
+from .dual_read_write import (
+    DualReadWriteShim,
+    DualWriteStrategy,
+    FeatureFlagState,
+    ReadStrategy,
+)
+from .audit import DataIntegrityAuditor, MigrationAuditReport
+
+__all__ = [
+    "ColumnDefinition",
+    "SchemaMigrator",
+    "TableDefinition",
+    "ConfigTranslator",
+    "DualReadWriteShim",
+    "DualWriteStrategy",
+    "FeatureFlagState",
+    "ReadStrategy",
+    "DataIntegrityAuditor",
+    "MigrationAuditReport",
+]

--- a/tools/migration/audit.py
+++ b/tools/migration/audit.py
@@ -1,0 +1,190 @@
+"""Post-migration data integrity auditing."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
+
+
+@dataclass
+class DriftRecord:
+    tenant_id: str
+    resource: str
+    record_id: str
+    differences: Dict[str, Tuple[Any, Any]]
+
+
+@dataclass
+class MigrationAuditReport:
+    """Structured result of a migration audit."""
+
+    matched_records: int
+    mismatched_records: int
+    missing_in_modern: List[str] = field(default_factory=list)
+    missing_in_legacy: List[str] = field(default_factory=list)
+    drifts: List[DriftRecord] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_successful(self) -> bool:
+        return not (self.mismatched_records or self.missing_in_modern or self.missing_in_legacy)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "matched_records": self.matched_records,
+            "mismatched_records": self.mismatched_records,
+            "missing_in_modern": self.missing_in_modern,
+            "missing_in_legacy": self.missing_in_legacy,
+            "drifts": [
+                {
+                    "tenant_id": drift.tenant_id,
+                    "resource": drift.resource,
+                    "record_id": drift.record_id,
+                    "differences": {key: [legacy, modern] for key, (legacy, modern) in drift.differences.items()},
+                }
+                for drift in self.drifts
+            ],
+            "metadata": self.metadata,
+        }
+
+    def write(self, path: Union[str, Path]) -> Path:
+        target = Path(path)
+        target.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True))
+        return target
+
+
+class DataIntegrityAuditor:
+    """Compare legacy and modern data snapshots."""
+
+    def __init__(self, *, tolerance: float = 0.0) -> None:
+        self.tolerance = tolerance
+
+    # ------------------------------------------------------------------
+    def load_snapshot(self, path: Union[str, Path]) -> Dict[str, Any]:
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(file_path)
+        raw = file_path.read_text()
+        if file_path.suffix.lower() in {".yml", ".yaml"}:
+            return json.loads(json.dumps(__import__("yaml").safe_load(raw)))
+        return json.loads(raw)
+
+    # ------------------------------------------------------------------
+    def compare(self, legacy_snapshot: Mapping[str, Any], modern_snapshot: Mapping[str, Any]) -> MigrationAuditReport:
+        legacy_index = self._build_index(legacy_snapshot)
+        modern_index = self._build_index(modern_snapshot)
+
+        matched = 0
+        mismatched = 0
+        missing_in_modern: List[str] = []
+        missing_in_legacy: List[str] = []
+        drifts: List[DriftRecord] = []
+
+        for key, legacy_record in legacy_index.items():
+            if key not in modern_index:
+                missing_in_modern.append(self._format_key(key))
+                continue
+            modern_record = modern_index[key]
+            if self._records_close(legacy_record, modern_record):
+                matched += 1
+            else:
+                mismatched += 1
+                differences = self._diff_record(legacy_record, modern_record)
+                drifts.append(
+                    DriftRecord(
+                        tenant_id=key[0],
+                        resource=key[1],
+                        record_id=key[2],
+                        differences=differences,
+                    )
+                )
+        for key in modern_index:
+            if key not in legacy_index:
+                missing_in_legacy.append(self._format_key(key))
+
+        return MigrationAuditReport(
+            matched_records=matched,
+            mismatched_records=mismatched,
+            missing_in_modern=missing_in_modern,
+            missing_in_legacy=missing_in_legacy,
+            drifts=drifts,
+            metadata={
+                "legacy_records": len(legacy_index),
+                "modern_records": len(modern_index),
+                "tolerance": self.tolerance,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    def _build_index(self, snapshot: Mapping[str, Any]) -> Dict[Tuple[str, str, str], Any]:
+        index: Dict[Tuple[str, str, str], Any] = {}
+        tenants = snapshot.get("tenants", {}) if isinstance(snapshot, Mapping) else snapshot
+        for tenant_id, tenant_payload in tenants.items():
+            if not isinstance(tenant_payload, Mapping):
+                index[(str(tenant_id), "root", "root")] = tenant_payload
+                continue
+            for resource, value in tenant_payload.items():
+                for record_id, payload in self._iterate_records(value):
+                    index[(str(tenant_id), str(resource), record_id)] = payload
+        return index
+
+    def _iterate_records(self, value: Any) -> Iterable[Tuple[str, Any]]:
+        if isinstance(value, list):
+            for item in value:
+                yield self._record_key(item), item
+        elif isinstance(value, Mapping):
+            if all(isinstance(v, Mapping) for v in value.values()):
+                for key, item in value.items():
+                    yield str(key), item
+            else:
+                yield "singleton", value
+        else:
+            yield "singleton", value
+
+    def _record_key(self, payload: Any) -> str:
+        if isinstance(payload, Mapping):
+            for key in ("id", "uuid", "external_id", "account_id"):
+                if key in payload:
+                    return str(payload[key])
+            digest = md5(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+            return f"hash:{digest}"
+        return str(payload)
+
+    def _records_close(self, legacy_record: Any, modern_record: Any) -> bool:
+        if legacy_record == modern_record:
+            return True
+        if isinstance(legacy_record, (int, float)) and isinstance(modern_record, (int, float)):
+            return abs(float(legacy_record) - float(modern_record)) <= self.tolerance
+        if isinstance(legacy_record, Mapping) and isinstance(modern_record, Mapping):
+            if set(legacy_record.keys()) != set(modern_record.keys()):
+                return False
+            return all(
+                self._records_close(legacy_record[key], modern_record[key])
+                for key in legacy_record
+            )
+        if isinstance(legacy_record, list) and isinstance(modern_record, list):
+            if len(legacy_record) != len(modern_record):
+                return False
+            return all(
+                self._records_close(left, right)
+                for left, right in zip(sorted(legacy_record, key=str), sorted(modern_record, key=str))
+            )
+        return False
+
+    def _diff_record(self, legacy_record: Any, modern_record: Any) -> Dict[str, Tuple[Any, Any]]:
+        if isinstance(legacy_record, Mapping) and isinstance(modern_record, Mapping):
+            differences: Dict[str, Tuple[Any, Any]] = {}
+            for key in sorted(set(legacy_record.keys()) | set(modern_record.keys())):
+                legacy_value = legacy_record.get(key)
+                modern_value = modern_record.get(key)
+                if not self._records_close(legacy_value, modern_value):
+                    differences[key] = (legacy_value, modern_value)
+            return differences
+        return {"value": (legacy_record, modern_record)}
+
+    def _format_key(self, key: Tuple[str, str, str]) -> str:
+        tenant, resource, record_id = key
+        return f"tenant={tenant} resource={resource} record={record_id}"

--- a/tools/migration/config_translator.py
+++ b/tools/migration/config_translator.py
@@ -1,0 +1,159 @@
+"""Translate legacy configuration files into the multi-tenant format."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
+
+import yaml
+
+
+def _read_structure(path: Union[str, Path]) -> Dict[str, Any]:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+    raw = file_path.read_text()
+    if file_path.suffix.lower() in {".yml", ".yaml"}:
+        return yaml.safe_load(raw) or {}
+    return json.loads(raw)
+
+
+def _deep_merge(base: Mapping[str, Any], override: Mapping[str, Any]) -> Dict[str, Any]:
+    """Merge dictionaries recursively without mutating the inputs."""
+
+    merged: Dict[str, Any] = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+class ConfigTranslator:
+    """Translate a legacy single-tenant configuration into tenant-scoped files."""
+
+    def __init__(
+        self,
+        base_config: Mapping[str, Any],
+        tenant_overrides: Mapping[str, Mapping[str, Any]],
+        *,
+        feature_flags: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.base_config = deepcopy(base_config)
+        self.tenant_overrides = {key: deepcopy(value) for key, value in tenant_overrides.items()}
+        self.feature_flags = dict(feature_flags or {})
+        self._translated: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_files(
+        cls,
+        base_config_path: Union[str, Path],
+        tenant_overrides_path: Union[str, Path],
+        *,
+        feature_flags_path: Optional[Union[str, Path]] = None,
+    ) -> "ConfigTranslator":
+        base = _read_structure(base_config_path)
+        overrides = _read_structure(tenant_overrides_path)
+        flags: Optional[Dict[str, Any]] = None
+        if feature_flags_path:
+            raw_flags = _read_structure(feature_flags_path)
+            if isinstance(raw_flags, Mapping) and "feature_flags" in raw_flags:
+                candidate = raw_flags.get("feature_flags")
+                flags = dict(candidate) if isinstance(candidate, Mapping) else None
+            elif isinstance(raw_flags, Mapping):
+                flags = dict(raw_flags)
+        tenants = overrides.get("tenants") if isinstance(overrides, Mapping) else overrides
+        if not isinstance(tenants, Mapping):
+            raise ValueError("Tenant overrides file must contain a 'tenants' mapping")
+        feature_flag_payload = flags or overrides.get("feature_flags", {})
+        if isinstance(feature_flag_payload, Mapping):
+            feature_flag_payload = dict(feature_flag_payload)
+        else:
+            feature_flag_payload = {}
+        return cls(base, tenants, feature_flags=feature_flag_payload)
+
+    # ------------------------------------------------------------------
+    def translate(self) -> Dict[str, Any]:
+        """Create the new configuration structure."""
+
+        tenants_config: Dict[str, Any] = {}
+        for tenant, overrides in self.tenant_overrides.items():
+            merged = _deep_merge(self.base_config, overrides)
+            tenants_config[tenant] = merged
+        self._translated = {
+            "global": {
+                "feature_flags": self.feature_flags,
+                "legacy_config_version": self.base_config.get("version", "1.0"),
+            },
+            "tenants": tenants_config,
+        }
+        return deepcopy(self._translated)
+
+    # ------------------------------------------------------------------
+    def translated(self) -> Dict[str, Any]:
+        if self._translated is None:
+            return self.translate()
+        return deepcopy(self._translated)
+
+    # ------------------------------------------------------------------
+    def write_outputs(
+        self,
+        output_dir: Union[str, Path],
+        *,
+        include_per_tenant: bool = True,
+    ) -> Tuple[Path, Dict[str, Path]]:
+        """Write the translated configuration to disk."""
+
+        directory = Path(output_dir)
+        directory.mkdir(parents=True, exist_ok=True)
+        master_path = directory / "multi_tenant_config.yaml"
+        yaml.safe_dump(self.translated(), master_path.open("w"), sort_keys=False)
+        per_tenant_files: Dict[str, Path] = {}
+        if include_per_tenant:
+            for tenant, config in self.translated()["tenants"].items():
+                tenant_path = directory / f"tenant_{tenant}.yaml"
+                yaml.safe_dump(config, tenant_path.open("w"), sort_keys=False)
+                per_tenant_files[tenant] = tenant_path
+        return master_path, per_tenant_files
+
+    # ------------------------------------------------------------------
+    def diff(self, tenant: str) -> Dict[str, Tuple[Any, Any]]:
+        """Return a key-level diff between the base configuration and overrides."""
+
+        if tenant not in self.tenant_overrides:
+            raise KeyError(f"Unknown tenant '{tenant}'")
+        diffs: Dict[str, Tuple[Any, Any]] = {}
+        overrides = self.tenant_overrides[tenant]
+        for key, value in overrides.items():
+            base_value = self.base_config.get(key)
+            if isinstance(value, Mapping) and isinstance(base_value, Mapping):
+                nested = ConfigTranslator(base_value, {tenant: value}).diff(tenant)
+                for nested_key, nested_diff in nested.items():
+                    diffs[f"{key}.{nested_key}"] = nested_diff
+            else:
+                if base_value != value:
+                    diffs[key] = (base_value, value)
+        return diffs
+
+    # ------------------------------------------------------------------
+    def build_runtime_payload(self) -> Dict[str, Any]:
+        """Return a payload optimised for runtime consumption."""
+
+        translated = self.translated()
+        payload = {
+            "feature_flags": translated["global"].get("feature_flags", {}),
+            "tenants": [],
+        }
+        for tenant, config in translated["tenants"].items():
+            payload["tenants"].append(
+                {
+                    "tenant_id": tenant,
+                    "config": config,
+                    "overrides": self.tenant_overrides.get(tenant, {}),
+                }
+            )
+        return payload

--- a/tools/migration/dual_read_write.py
+++ b/tools/migration/dual_read_write.py
@@ -1,0 +1,220 @@
+"""Dual read/write shims to support hybrid legacy + microservice deployments."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Optional, Protocol
+
+
+class DataAdapter(Protocol):
+    """Protocol describing a storage adapter."""
+
+    def read(self, resource: str, tenant_id: str, **kwargs: Any) -> Any:  # pragma: no cover - Protocol signature
+        ...
+
+    def write(self, resource: str, tenant_id: str, payload: Any, **kwargs: Any) -> Any:  # pragma: no cover - Protocol signature
+        ...
+
+    def delete(self, resource: str, tenant_id: str, **kwargs: Any) -> Any:  # pragma: no cover - Protocol signature
+        ...
+
+
+class DualWriteStrategy(str, Enum):
+    """Strategies for dual-write behaviour."""
+
+    MIRROR = "mirror"  # Write to both stores
+    LEGACY_PRIMARY = "legacy-primary"  # Legacy is source of truth, modern is best effort
+    MODERN_PRIMARY = "modern-primary"  # Modern is source of truth, legacy receives backfill
+    LEGACY_ONLY = "legacy-only"
+    MODERN_ONLY = "modern-only"
+
+
+class ReadStrategy(str, Enum):
+    """Strategies for dual-read behaviour."""
+
+    PREFER_LEGACY = "prefer-legacy"
+    PREFER_MODERN = "prefer-modern"
+    COMPARE = "compare"  # Read both and compare for drift
+
+
+@dataclass
+class FeatureFlagState:
+    """Stateful feature flags powering the shim."""
+
+    hybrid_mode_enabled: bool = False
+    prefer_legacy_reads: bool = False
+    dual_write_strategy: DualWriteStrategy = DualWriteStrategy.MIRROR
+    cutover_complete: bool = False
+    guardrail_enabled: bool = True
+    drift_tolerance: float = 0.0
+
+    def as_env(self) -> Dict[str, str]:
+        """Return an environment-compatible representation of the flags."""
+
+        return {
+            "HYBRID_MODE_ENABLED": str(self.hybrid_mode_enabled).lower(),
+            "LEGACY_READ_ENABLED": str(self.prefer_legacy_reads or self.hybrid_mode_enabled).lower(),
+            "DUAL_WRITE_STRATEGY": self.dual_write_strategy.value,
+            "CUTOVER_COMPLETED": str(self.cutover_complete).lower(),
+            "CUTOVER_GUARDRAIL_ENABLED": str(self.guardrail_enabled).lower(),
+            "MIGRATION_DRIFT_TOLERANCE": str(self.drift_tolerance),
+        }
+
+
+AuditCallback = Callable[[str, str, Any, Any], None]
+
+
+@dataclass
+class DualReadWriteShim:
+    """Coordinate reads and writes during the hybrid migration phase."""
+
+    legacy_adapter: DataAdapter
+    modern_adapter: DataAdapter
+    feature_flags: FeatureFlagState = field(default_factory=FeatureFlagState)
+    audit_callback: Optional[AuditCallback] = None
+    _callback_expects_tuple: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        if self.audit_callback is not None:
+            try:
+                parameters = inspect.signature(self.audit_callback).parameters
+                self._callback_expects_tuple = len(parameters) == 1
+            except (TypeError, ValueError):
+                self._callback_expects_tuple = False
+
+    def read(
+        self,
+        resource: str,
+        tenant_id: str,
+        *,
+        strategy: Optional[ReadStrategy] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Read data according to the configured hybrid strategy."""
+
+        if not self.feature_flags.hybrid_mode_enabled or self.feature_flags.cutover_complete:
+            return self.modern_adapter.read(resource, tenant_id, **kwargs)
+
+        strategy = strategy or (
+            ReadStrategy.PREFER_LEGACY if self.feature_flags.prefer_legacy_reads else ReadStrategy.COMPARE
+        )
+        legacy_result = None
+        modern_result = None
+
+        if strategy is ReadStrategy.PREFER_LEGACY:
+            legacy_result = self.legacy_adapter.read(resource, tenant_id, **kwargs)
+            modern_result = self.modern_adapter.read(resource, tenant_id, **kwargs)
+            self._audit(resource, tenant_id, legacy_result, modern_result)
+            return legacy_result
+        if strategy is ReadStrategy.PREFER_MODERN:
+            legacy_result = self.legacy_adapter.read(resource, tenant_id, **kwargs)
+            modern_result = self.modern_adapter.read(resource, tenant_id, **kwargs)
+            self._audit(resource, tenant_id, legacy_result, modern_result)
+            return modern_result
+
+        # Compare strategy (default) reads both, audits and returns modern data
+        legacy_result = self.legacy_adapter.read(resource, tenant_id, **kwargs)
+        modern_result = self.modern_adapter.read(resource, tenant_id, **kwargs)
+        self._audit(resource, tenant_id, legacy_result, modern_result)
+        return modern_result
+
+    def write(
+        self,
+        resource: str,
+        tenant_id: str,
+        payload: Any,
+        *,
+        strategy: Optional[DualWriteStrategy] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Write to both data stores according to the configured strategy."""
+
+        strategy = strategy or self.feature_flags.dual_write_strategy
+        results: Dict[str, Any] = {}
+
+        if strategy is DualWriteStrategy.LEGACY_ONLY:
+            results["legacy"] = self.legacy_adapter.write(resource, tenant_id, payload, **kwargs)
+            results["modern"] = None
+            return results
+        if strategy is DualWriteStrategy.MODERN_ONLY:
+            results["legacy"] = None
+            results["modern"] = self.modern_adapter.write(resource, tenant_id, payload, **kwargs)
+            return results
+
+        # For mirror, legacy-primary and modern-primary we attempt to write to both
+        results["legacy"] = self.legacy_adapter.write(resource, tenant_id, payload, **kwargs)
+        results["modern"] = self.modern_adapter.write(resource, tenant_id, payload, **kwargs)
+
+        if self.feature_flags.guardrail_enabled and results.get("legacy") != results.get("modern"):
+            self._audit(resource, tenant_id, results.get("legacy"), results.get("modern"))
+        return results
+
+    def reconcile(
+        self,
+        resource: str,
+        tenant_id: str,
+        *,
+        raise_on_drift: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Compare legacy and modern data and optionally raise on drift."""
+
+        legacy_result = self.legacy_adapter.read(resource, tenant_id, **kwargs)
+        modern_result = self.modern_adapter.read(resource, tenant_id, **kwargs)
+        drift_detected = legacy_result != modern_result
+        if drift_detected and raise_on_drift and self.feature_flags.guardrail_enabled:
+            raise RuntimeError(
+                f"Data drift detected for resource '{resource}' tenant '{tenant_id}': "
+                f"legacy={legacy_result!r} modern={modern_result!r}"
+            )
+        self._audit(resource, tenant_id, legacy_result, modern_result)
+        return {
+            "resource": resource,
+            "tenant_id": tenant_id,
+            "legacy": legacy_result,
+            "modern": modern_result,
+            "drift_detected": drift_detected,
+        }
+
+    def cutover(self) -> None:
+        """Mark the cutover as completed and disable legacy paths."""
+
+        self.feature_flags.cutover_complete = True
+        self.feature_flags.hybrid_mode_enabled = False
+
+    # ------------------------------------------------------------------
+    def _audit(self, resource: str, tenant_id: str, legacy_value: Any, modern_value: Any) -> None:
+        if not self.audit_callback:
+            return
+        if self._values_close(legacy_value, modern_value):
+            return
+        if self._callback_expects_tuple:
+            self.audit_callback((resource, tenant_id, legacy_value, modern_value))
+        else:
+            self.audit_callback(resource, tenant_id, legacy_value, modern_value)
+
+    # ------------------------------------------------------------------
+    def _values_close(self, legacy_value: Any, modern_value: Any) -> bool:
+        if legacy_value == modern_value:
+            return True
+        tolerance = self.feature_flags.drift_tolerance
+        if isinstance(legacy_value, (int, float)) and isinstance(modern_value, (int, float)):
+            return abs(float(legacy_value) - float(modern_value)) <= tolerance
+        if isinstance(legacy_value, dict) and isinstance(modern_value, dict):
+            legacy_keys = set(legacy_value.keys())
+            modern_keys = set(modern_value.keys())
+            if legacy_keys != modern_keys:
+                return False
+            return all(
+                self._values_close(legacy_value[key], modern_value[key]) for key in legacy_keys
+            )
+        if isinstance(legacy_value, (list, tuple)) and isinstance(modern_value, (list, tuple)):
+            if len(legacy_value) != len(modern_value):
+                return False
+            return all(
+                self._values_close(left, right)
+                for left, right in zip(legacy_value, modern_value)
+            )
+        return False

--- a/tools/migration/schema_migrator.py
+++ b/tools/migration/schema_migrator.py
@@ -1,0 +1,289 @@
+"""Utilities for generating multi-tenant database schemas."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
+
+import yaml
+
+
+@dataclass
+class ColumnDefinition:
+    """Representation of a database column."""
+
+    name: str
+    type: str
+    nullable: bool = True
+    default: Optional[str] = None
+    primary_key: bool = False
+    unique: bool = False
+
+    def to_sql(self) -> str:
+        """Render the column as SQL."""
+
+        parts: List[str] = [f'"{self.name}" {self.type}']
+        if not self.nullable:
+            parts.append("NOT NULL")
+        if self.unique:
+            parts.append("UNIQUE")
+        if self.default is not None:
+            parts.append(f"DEFAULT {self.default}")
+        return " ".join(parts)
+
+
+@dataclass
+class TableDefinition:
+    """Representation of a legacy table that should become multi-tenant."""
+
+    name: str
+    columns: List[ColumnDefinition]
+    indexes: List[Dict[str, Any]] = field(default_factory=list)
+    tenant_lookup_key: Optional[str] = None
+    comment: Optional[str] = None
+
+    def primary_key_columns(self) -> List[str]:
+        return [column.name for column in self.columns if column.primary_key]
+
+    def clone(self, *, name: Optional[str] = None) -> "TableDefinition":
+        """Return a copy of the table definition."""
+
+        return TableDefinition(
+            name=name or self.name,
+            columns=[ColumnDefinition(**column.__dict__) for column in self.columns],
+            indexes=[dict(index) for index in self.indexes],
+            tenant_lookup_key=self.tenant_lookup_key,
+            comment=self.comment,
+        )
+
+
+class SchemaMigrator:
+    """Generate SQL statements to migrate to the multi-tenant schema."""
+
+    def __init__(
+        self,
+        legacy_schema: Dict[str, Any],
+        *,
+        tenant_id_type: str = "UUID",
+        audit_columns: Optional[Sequence[ColumnDefinition]] = None,
+    ) -> None:
+        self.legacy_schema = legacy_schema
+        self.tenant_id_type = tenant_id_type
+        self.audit_columns = list(
+            audit_columns
+            or (
+                ColumnDefinition(
+                    name="migrated_at",
+                    type="TIMESTAMPTZ",
+                    nullable=False,
+                    default="CURRENT_TIMESTAMP",
+                ),
+                ColumnDefinition(
+                    name="source_legacy_pk",
+                    type="TEXT",
+                    nullable=False,
+                ),
+                ColumnDefinition(
+                    name="source_hash",
+                    type="TEXT",
+                    nullable=False,
+                ),
+            )
+        )
+        self.tables = [self._parse_table(item) for item in legacy_schema.get("tables", [])]
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_file(
+        cls,
+        path: Union[str, Path],
+        *,
+        tenant_id_type: str = "UUID",
+        audit_columns: Optional[Sequence[ColumnDefinition]] = None,
+    ) -> "SchemaMigrator":
+        """Load schema metadata from JSON or YAML."""
+
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(file_path)
+
+        raw_data: Dict[str, Any]
+        if file_path.suffix.lower() in {".yml", ".yaml"}:
+            raw_data = yaml.safe_load(file_path.read_text())
+        else:
+            raw_data = json.loads(file_path.read_text())
+        if not isinstance(raw_data, dict):
+            raise ValueError("Schema file must contain a JSON/YAML object")
+        return cls(raw_data, tenant_id_type=tenant_id_type, audit_columns=audit_columns)
+
+    def _parse_table(self, table: Dict[str, Any]) -> TableDefinition:
+        columns: List[ColumnDefinition] = []
+        for column in table.get("columns", []):
+            columns.append(
+                ColumnDefinition(
+                    name=column["name"],
+                    type=column.get("type", "TEXT"),
+                    nullable=column.get("nullable", True),
+                    default=column.get("default"),
+                    primary_key=column.get("primary_key", False),
+                    unique=column.get("unique", False),
+                )
+            )
+        indexes = [dict(index) for index in table.get("indexes", [])]
+        tenant_lookup_key = table.get("tenant_lookup_key")
+        return TableDefinition(
+            name=table["name"],
+            columns=columns,
+            indexes=indexes,
+            tenant_lookup_key=tenant_lookup_key,
+            comment=table.get("comment"),
+        )
+
+    # ------------------------------------------------------------------
+    # Schema generation
+    # ------------------------------------------------------------------
+    def generate_schema_sql(self) -> str:
+        """Generate CREATE TABLE statements for the multi-tenant schema."""
+
+        statements: List[str] = []
+        for table in self.tables:
+            statements.append(self._render_multi_tenant_table(table))
+        return "\n\n".join(statements)
+
+    def _render_multi_tenant_table(self, table: TableDefinition) -> str:
+        multi_tenant_table = self._build_multi_tenant_table(table)
+        column_lines = [column.to_sql() for column in multi_tenant_table.columns]
+        pk_columns = multi_tenant_table.primary_key_columns()
+        if "tenant_id" not in pk_columns:
+            pk_columns = ["tenant_id", *pk_columns]
+        constraint_lines: List[str] = []
+        if pk_columns:
+            cols = ", ".join(f'"{column}"' for column in pk_columns)
+            constraint_lines.append(f"PRIMARY KEY ({cols})")
+        create_stmt = [
+            f"-- {multi_tenant_table.comment or 'Auto-generated multi-tenant table'}",
+            f"CREATE TABLE IF NOT EXISTS \"{multi_tenant_table.name}\" (",
+            "    " + ",\n    ".join(column_lines + constraint_lines),
+            ");",
+        ]
+        for index in multi_tenant_table.indexes:
+            index_name = index.get("name") or f"{multi_tenant_table.name}_{'_'.join(index.get('columns', []))}_idx"
+            column_list = ", ".join(f'\"{col}\"' for col in index.get("columns", []))
+            unique = "UNIQUE " if index.get("unique") else ""
+            create_stmt.append(
+                f"CREATE {unique}INDEX IF NOT EXISTS \"{index_name}\" ON \"{multi_tenant_table.name}\" ({column_list});"
+            )
+        return "\n".join(create_stmt)
+
+    def _build_multi_tenant_table(self, table: TableDefinition) -> TableDefinition:
+        clone = table.clone(name=f"tenant_{table.name}")
+        existing_names = {column.name for column in clone.columns}
+        tenant_column = ColumnDefinition(
+            name="tenant_id",
+            type=self.tenant_id_type,
+            nullable=False,
+        )
+        clone.columns.insert(0, tenant_column)
+        existing_names.add("tenant_id")
+        for audit_column in self.audit_columns:
+            if audit_column.name not in existing_names and audit_column.name != "tenant_id":
+                clone.columns.append(audit_column)
+                existing_names.add(audit_column.name)
+        # Ensure indexes contain tenant dimension
+        composite_index_columns = ["tenant_id"] + [
+            column.name for column in table.columns if column.primary_key
+        ]
+        clone.indexes.append(
+            {
+                "name": f"{clone.name}_tenant_scope_idx",
+                "columns": composite_index_columns,
+                "unique": True,
+            }
+        )
+        clone.comment = (
+            table.comment
+            or f"Multi-tenant version of {table.name} with tenant scoping enforced."
+        )
+        return clone
+
+    # ------------------------------------------------------------------
+    # Migration planning
+    # ------------------------------------------------------------------
+    def generate_migration_plan(self, tenant_mappings: Dict[str, Dict[str, Any]]) -> List[str]:
+        """Return SQL statements for migrating data for the provided tenants."""
+
+        plan: List[str] = []
+        for table in self.tables:
+            mt_table = f"tenant_{table.name}"
+            lookup_key = table.tenant_lookup_key or "account_id"
+            selected_columns = [column.name for column in table.columns]
+            for tenant_id, config in tenant_mappings.items():
+                raw_accounts = config.get("legacy_accounts")
+                if raw_accounts is None:
+                    raw_accounts = []
+                elif isinstance(raw_accounts, str):
+                    raw_accounts = [raw_accounts]
+                legacy_account = config.get("legacy_account")
+                if legacy_account:
+                    raw_accounts.append(legacy_account)
+                legacy_accounts = [account for account in raw_accounts if account]
+                if not legacy_accounts:
+                    legacy_accounts = ["*"]
+                for legacy_account in legacy_accounts:
+                    where_clause = ""
+                    if legacy_account != "*":
+                        where_clause = f"WHERE {lookup_key} = '{legacy_account}'"
+                    insert_columns = ", ".join([
+                        '"tenant_id"',
+                        *[f'"{column}"' for column in selected_columns],
+                        '"migrated_at"',
+                        '"source_legacy_pk"',
+                        '"source_hash"',
+                    ])
+                    conflict_columns = ", ".join([
+                        '"tenant_id"',
+                        *[f'"{column}"' for column in (selected_columns or ["source_legacy_pk"])],
+                    ])
+                    source_columns = ", ".join([
+                        f"'{tenant_id}'",
+                        *selected_columns,
+                        "CURRENT_TIMESTAMP",
+                        f"CAST({lookup_key} AS TEXT)",
+                        self._hash_expression(selected_columns),
+                    ])
+                    statement = (
+                        f"INSERT INTO \"{mt_table}\" ({insert_columns})\n"
+                        f"SELECT {source_columns}\n"
+                        f"FROM \"{table.name}\"\n"
+                        f"{where_clause}\n"
+                        f"ON CONFLICT ({conflict_columns}) DO UPDATE SET\n"
+                        "    migrated_at = EXCLUDED.migrated_at,\n"
+                        "    source_hash = EXCLUDED.source_hash;"
+                    )
+                    plan.append(statement)
+        return plan
+
+    def _hash_expression(self, columns: Iterable[str]) -> str:
+        if not columns:
+            return "md5('noop')"
+        expressions = [f"COALESCE(CAST({column} AS TEXT), '')" for column in columns]
+        expr = " || '|' || ".join(expressions)
+        return f"md5({expr})"
+
+    def dump_schema(self, output: Union[str, Path]) -> Path:
+        """Write generated schema SQL to disk."""
+
+        target = Path(output)
+        target.write_text(self.generate_schema_sql())
+        return target
+
+    def dump_plan(self, tenant_mappings: Dict[str, Dict[str, Any]], output: Union[str, Path]) -> Path:
+        """Write migration plan SQL to disk."""
+
+        target = Path(output)
+        target.write_text("\n\n".join(self.generate_migration_plan(tenant_mappings)))
+        return target

--- a/tools/migration/tenant_migration.py
+++ b/tools/migration/tenant_migration.py
@@ -1,0 +1,167 @@
+"""CLI utilities for migrating LegacyCoinTrader tenants."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+if __package__ is None or __package__ == "":
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from tools.migration.audit import DataIntegrityAuditor  # type: ignore
+    from tools.migration.config_translator import ConfigTranslator  # type: ignore
+    from tools.migration.dual_read_write import FeatureFlagState  # type: ignore
+    from tools.migration.schema_migrator import SchemaMigrator  # type: ignore
+else:
+    from .audit import DataIntegrityAuditor
+    from .config_translator import ConfigTranslator
+    from .dual_read_write import FeatureFlagState
+    from .schema_migrator import SchemaMigrator
+
+
+def _load_mapping(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    raw = path.read_text()
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        import yaml  # Local import to avoid mandatory dependency for consumers
+
+        return yaml.safe_load(raw) or {}
+    return json.loads(raw)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Tenant migration toolkit")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    schema_parser = subparsers.add_parser("generate-schema", help="Generate multi-tenant schema SQL")
+    schema_parser.add_argument("--schema", required=True, type=Path, help="Path to legacy schema metadata (JSON/YAML)")
+    schema_parser.add_argument("--output", required=True, type=Path, help="Where to write the generated SQL")
+    schema_parser.add_argument("--tenant-id-type", default="UUID", help="Column type to use for tenant identifiers")
+
+    plan_parser = subparsers.add_parser("migration-plan", help="Generate migration SQL for tenant mappings")
+    plan_parser.add_argument("--schema", required=True, type=Path, help="Legacy schema metadata file")
+    plan_parser.add_argument("--mapping", required=True, type=Path, help="Tenant mapping definition (JSON/YAML)")
+    plan_parser.add_argument("--output", required=True, type=Path, help="Output SQL file")
+
+    translate_parser = subparsers.add_parser("translate-config", help="Translate legacy configuration for tenants")
+    translate_parser.add_argument("--base-config", required=True, type=Path, help="Legacy configuration file")
+    translate_parser.add_argument("--tenant-overrides", required=True, type=Path, help="Tenant override definitions")
+    translate_parser.add_argument(
+        "--feature-flags",
+        type=Path,
+        help="Optional feature flag definitions",
+    )
+    translate_parser.add_argument("--output-dir", required=True, type=Path, help="Directory for translated configs")
+
+    audit_parser = subparsers.add_parser("audit", help="Validate data integrity between legacy and modern snapshots")
+    audit_parser.add_argument("--legacy-snapshot", required=True, type=Path)
+    audit_parser.add_argument("--modern-snapshot", required=True, type=Path)
+    audit_parser.add_argument("--report-path", required=True, type=Path)
+    audit_parser.add_argument("--tolerance", type=float, default=0.0, help="Numeric tolerance for comparison")
+    audit_parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Exit with code 2 when drift or missing records are detected",
+    )
+
+    flags_parser = subparsers.add_parser("flags", help="Render hybrid feature flags as environment variables")
+    flags_parser.add_argument("--hybrid", action="store_true", help="Enable hybrid mode")
+    flags_parser.add_argument("--prefer-legacy", action="store_true", help="Prefer legacy reads")
+    flags_parser.add_argument(
+        "--strategy",
+        choices=["mirror", "legacy-primary", "modern-primary", "legacy-only", "modern-only"],
+        default="mirror",
+    )
+    flags_parser.add_argument("--cutover-complete", action="store_true", help="Mark cutover as complete")
+    flags_parser.add_argument("--guardrail", action="store_true", help="Enable guardrail enforcement")
+    flags_parser.add_argument("--tolerance", type=float, default=0.0, help="Allowed drift tolerance")
+
+    return parser
+
+
+def handle_generate_schema(args: argparse.Namespace) -> None:
+    migrator = SchemaMigrator.from_file(args.schema, tenant_id_type=args.tenant_id_type)
+    migrator.dump_schema(args.output)
+    print(f"Generated schema written to {args.output}")
+
+
+def handle_migration_plan(args: argparse.Namespace) -> None:
+    migrator = SchemaMigrator.from_file(args.schema)
+    mapping = _load_mapping(args.mapping)
+    tenant_mapping = mapping.get("tenants", mapping)
+    if not isinstance(tenant_mapping, dict):
+        raise ValueError("Tenant mapping must be a dictionary")
+    migrator.dump_plan(tenant_mapping, args.output)
+    print(f"Migration plan written to {args.output}")
+
+
+def handle_translate_config(args: argparse.Namespace) -> None:
+    translator = ConfigTranslator.from_files(
+        base_config_path=args.base_config,
+        tenant_overrides_path=args.tenant_overrides,
+        feature_flags_path=args.feature_flags,
+    )
+    master_path, per_tenant = translator.write_outputs(args.output_dir)
+    print(f"Master config written to {master_path}")
+    if per_tenant:
+        print("Per-tenant configs:")
+        for tenant, path in per_tenant.items():
+            print(f"  {tenant}: {path}")
+
+
+def handle_audit(args: argparse.Namespace) -> int:
+    auditor = DataIntegrityAuditor(tolerance=args.tolerance)
+    legacy = auditor.load_snapshot(args.legacy_snapshot)
+    modern = auditor.load_snapshot(args.modern_snapshot)
+    report = auditor.compare(legacy, modern)
+    report.write(args.report_path)
+    print(json.dumps(report.to_dict(), indent=2))
+    if args.fail_on_drift and not report.is_successful:
+        print("Drift detected during migration audit", file=sys.stderr)
+        return 2
+    return 0
+
+
+def handle_flags(args: argparse.Namespace) -> None:
+    from .dual_read_write import DualWriteStrategy
+
+    flags = FeatureFlagState(
+        hybrid_mode_enabled=args.hybrid,
+        prefer_legacy_reads=args.prefer_legacy,
+        dual_write_strategy=DualWriteStrategy(args.strategy),
+        cutover_complete=args.cutover_complete,
+        guardrail_enabled=args.guardrail or args.cutover_complete,
+        drift_tolerance=args.tolerance,
+    )
+    for key, value in flags.as_env().items():
+        print(f"{key}={value}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "generate-schema":
+        handle_generate_schema(args)
+        return 0
+    if args.command == "migration-plan":
+        handle_migration_plan(args)
+        return 0
+    if args.command == "translate-config":
+        handle_translate_config(args)
+        return 0
+    if args.command == "audit":
+        return handle_audit(args)
+    if args.command == "flags":
+        handle_flags(args)
+        return 0
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a tenant migration toolkit with schema generation, config translation, dual read/write shim support, and regression tests
- document the hybrid rollout playbook and customer communication templates for CAB-aligned migrations
- extend docker-compose, Helm charts, and start scripts with hybrid feature flags plus a CI-friendly migration audit target

## Testing
- pytest tests/test_migration_toolkit.py
- make migration-audit

------
https://chatgpt.com/codex/tasks/task_e_68cae9303efc833093c066ccaf6d0e4b